### PR TITLE
Fix compiler warnings across modules (sprintf, strncpy, buffers)

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -45,7 +45,8 @@ line_ed(char *fname, struct TEXT_HEADER * th, int edit_text, int allow_say, int 
     unsigned char c, c2;
     char *space, *cptr, *j, *p, outc, lastchar, *confname;
     char *buf, *oldbuf;
-    LINE waste, cmd, arg, newname, upcasearg;
+    LINE waste, cmd, arg, upcasearg;
+    char newname[128];  /* increased buffer size to fix truncation issue, modified on 2025-07-12, PL */
     int fd, len, count, edit_line, buflen, i, newconf, origconf, marcel, qt;
     int ll;
     long tn, numlines;
@@ -489,8 +490,8 @@ line_ed(char *fname, struct TEXT_HEADER * th, int edit_text, int allow_say, int 
                         if (Current_conf)
                             sprintf(newname, "%s/%d/%ld", SKLAFF_DB,
                                 Current_conf, th->comment_num);
-                        else
-                            sprintf(newname, "%s/%ld", Mbox, th->comment_num);
+                        else                        
+			    snprintf(newname, sizeof(newname), "%.60s/%ld", Mbox, th->comment_num); /* modified on 2025-07-12, PL */
                         fd = open_file(newname, 0);
                         buf = read_file(fd);
                         oldbuf = buf;

--- a/sklaff.h
+++ b/sklaff.h
@@ -501,7 +501,7 @@ int more_text(void);
 void free_text_entry(struct TEXT_ENTRY *);
 long save_mailcopy(char *, char *, char *);
 void cnvnat(char *, int);
-void int2ms(int, char *);
+void int2ms(int, char[4]);  /* modified on 2025-07-12, PL */
 long age_to_textno(long);
 
 /* user.c */

--- a/sklaffadm.c
+++ b/sklaffadm.c
@@ -39,7 +39,7 @@ main(int argc, char *argv[])
     char *name, *buf, *oldbuf, *buf2, *oldbuf2, *buf3, *oldbuf3;
     int u_num, fd, conf, fd2, fd3, pdate, ndays;
     long ftext, ntext, otext, ttext, ltext;
-    LONG_LINE dirname, fname, udir, uname;
+    char dirname[256], fname[256], udir[256], uname[256];  /* promoted to 256 to prevent truncation, modified on 2025-07-13, PL */
     LINE cname, args;
     struct ACTIVE_ENTRY ae;
     struct TEXT_HEADER th;
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
             buf = get_conf_entry(buf, &ce);
             if (buf) {
                 otext = 0;
-                sprintf(udir, "%s/%d%s", FILE_DB, ce.num, INDEX_FILE);
+                snprintf(udir, sizeof(udir), "%s/%d%s", FILE_DB, ce.num, INDEX_FILE); /* modified on 2025-07-12, PL  */
                 if ((fd = open_file(udir, OPEN_QUIET)) != -1) {
                     buf2 = read_file(fd);
                     oldbuf2 = buf2;
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
                     while (buf2) {
                         buf2 = get_file_entry(buf2, &fe);
                         if (buf2) {
-                            sprintf(udir, "%s/%d/%s", FILE_DB, ce.num,
+                            snprintf(udir, sizeof(udir), "%s/%d/%s", FILE_DB, ce.num, /* modified on 2025-07-12, PL  */
                                 fe.name);
                             if (stat(udir, &fs) == -1) {
                                 fs.st_size = 0;
@@ -214,7 +214,7 @@ main(int argc, char *argv[])
             buf = get_user_entry(buf, &ue);
             if (buf) {
                 mbox_dir(ue.num, udir);
-                sprintf(uname, "%s%s", udir, MAILBOX_FILE);
+                snprintf(uname, sizeof(uname), "%.240s%s", udir, MAILBOX_FILE); /* modified on 2025-07-12, PL  */
                 fd2 = open_file(uname, 0);
                 buf2 = read_file(fd2);
                 oldbuf2 = buf2;
@@ -248,13 +248,13 @@ main(int argc, char *argv[])
                         output("\n%s\n\n", MSG_WRONGCONF);
                     } else {
                         ce2 = get_conf_struct(conf);
-                        sprintf(dirname, "%s/%d/", SKLAFF_DB, conf);
+                        snprintf(dirname, sizeof(dirname), "%s/%d/", SKLAFF_DB, conf); /* modified on 2025-07-12, PL  */
                         ftext = first_text(conf, Uid);
                         ltext = last_text(conf, Uid);
                         ltext = ltext - ntext + 1;
                         ttext = 0;
                         while ((ftext < ltext) && ce2->life) {
-                            sprintf(fname, "%s%ld", dirname, ftext);
+                            snprintf(fname, sizeof(fname), "%.244s%ld", dirname, ftext); /* modified on 2025-07-12, PL  */
                             ftext++;
                             if (file_exists(fname) != -1) {
                                 fd = open_file(fname, 0);
@@ -288,12 +288,12 @@ main(int argc, char *argv[])
                         while (buf) {
                             buf = get_conf_entry(buf, &ce);
                             if (buf) {
-                                sprintf(dirname, "%s/%d/", SKLAFF_DB, ce.num);
+                                snprintf(dirname, sizeof(dirname), "%s/%d/", SKLAFF_DB, ce.num); /* modified on 2025-07-12, PL  */
                                 ftext = first_text(ce.num, Uid);
                                 ltext = last_text(ce.num, Uid);
                                 ltext = ltext - ntext + 1;
                                 while ((ftext < ltext) && ce.life) {
-                                    sprintf(fname, "%s%ld", dirname, ftext);
+                                    snprintf(fname, sizeof(fname), "%.244s%ld", dirname, ftext); /* modified on 2025-07-12, PL  */
                                     ftext++;
                                     if (file_exists(fname) != -1) {
                                         fd2 = open_file(fname, 0);
@@ -335,7 +335,7 @@ main(int argc, char *argv[])
                         output("%s", MSG_EUSERN);
                     } else {
                         mbox_dir(conf, dirname);
-                        strcpy(fname, dirname);
+                        strlcpy(fname, dirname, sizeof(fname)); /* modified on 2025-07-12, PL  */
                         strcat(fname, MAILBOX_FILE);
                         fd = open_file(fname, 0);
                         buf = read_file(fd);
@@ -348,7 +348,7 @@ main(int argc, char *argv[])
                         ltext = ltext - ntext + 1;
                         ttext = 0;
                         while ((ftext < ltext) && ce.life) {
-                            sprintf(fname, "%s/%ld", dirname, ftext);
+                            snprintf(fname, sizeof(fname), "%.244ss/%ld", dirname, ftext); /* modified on 2025-07-12, PL  */
                             ftext++;
                             if (file_exists(fname) != -1) {
                                 fd2 = open_file(fname, 0);
@@ -381,7 +381,7 @@ main(int argc, char *argv[])
                             buf = get_user_entry(buf, &ue);
                             if (buf) {
                                 mbox_dir(ue.num, dirname);
-                                strcpy(fname, dirname);
+                                strlcpy(fname, dirname, sizeof(fname)); /* modified on 2025-07-12, PL  */
                                 strcat(fname, MAILBOX_FILE);
                                 fd3 = open_file(fname, 0);
                                 buf3 = read_file(fd3);
@@ -393,7 +393,7 @@ main(int argc, char *argv[])
                                 ltext = ce.last_text;
                                 ltext = ltext - ntext + 1;
                                 while ((ftext < ltext) && ce.life) {
-                                    sprintf(fname, "%s/%ld", dirname, ftext);
+                                    snprintf(fname, sizeof(fname), "%.244s/%ld", dirname, ftext);  /* modified on 2025-07-13, PL */
                                     ftext++;
                                     if (file_exists(fname) != -1) {
                                         fd2 = open_file(fname, 0);
@@ -479,7 +479,7 @@ main(int argc, char *argv[])
             output("etc/down %s\n\n", MSG_CREATED);
             sleep(3);
             output("%s\n", MSG_NOTIFY);
-            strcpy(args, MSG_EXITNOW);
+            strlcpy(args, MSG_EXITNOW, sizeof(args)); /* modified on 2025-07-12, PL  */
             Uid = -2;
             cmd_yell(args);
             fflush(stdout);

--- a/survey.c
+++ b/survey.c
@@ -39,7 +39,8 @@ struct RESSHOW {
 
 /* static int resshowcompare(struct RESSHOW *, struct RESSHOW *); */
 static int parse_survey_line(char *);
-static int input_survey_quest(char *, char *, int, int);
+/* static int input_survey_quest(char *, char *, int, int); */
+static int input_survey_quest(LINE lin, LINE reply, int qtype, int flag); /* modified on 2025-07-12, PL */
 
 int
 make_survey(char *reply, int *quest, LINE ll, int flag)
@@ -69,7 +70,8 @@ int
 save_survey_result(long survey, int conf, char *survey_result, int n_quest)
 {
     int fd, i, j, ret, n;
-    LINE confdir, resfile;
+    LINE confdir;
+    char resfile[128];  /* increased from LINE (80) to fix sprintf overflow, modified on 2025-07-12, PL */
     char *buf, *fbuf, *t;
     char saveanswer[4];
     struct RESSHOW *resbuf;
@@ -97,7 +99,7 @@ save_survey_result(long survey, int conf, char *survey_result, int n_quest)
 
         if (conf >= 0) {
             sprintf(confdir, "%s/%d/", SKLAFF_DB, conf);
-            sprintf(resfile, "%s%ld.result", confdir, survey);
+            snprintf(resfile, sizeof(resfile), "%s%ld.result", confdir, survey);  /* modified on 2025-07-12, PL */
 
             if ((fd = open_file(resfile, OPEN_QUIET)) == -1) {
                 if ((fd = open_file(resfile, OPEN_CREATE)) == -1) {
@@ -291,7 +293,10 @@ show_survey_result(long survey, int conf, struct TEXT_BODY *tbstart, int n_quest
     struct TEXT_BODY *tb, *tbut;
     struct TEXT_ENTRY te;
     int fd, i, j, k, n, quest, qtype, nalt, n2;
-    LINE confdir, resfile, infofile, utlinje, uttmp;
+    LINE confdir, uttmp;
+    char resfile[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
+    char infofile[128];  /* increased from LINE (80) to fix sprintf overflow, modified on 2025-07-12, PL */
+    char utlinje[128];  /* increased from LINE (80) to fix sprintf overflow, modified on 2025-07-12, PL */
     char *buf, *t, *utbuf, *buf2;
     struct RESSHOW *resbuf = NULL;
     long *repbuf;
@@ -550,7 +555,8 @@ int
 mark_survey_as_taken(long survey, int conf)
 {
     int fd;
-    LINE confdir, infofile;
+    LINE confdir;
+    char infofile[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     char *buf, *fbuf;
 
 #ifdef SURVEYDEBUG
@@ -636,7 +642,8 @@ int
 check_if_survey_taken(long survey, int conf)
 {
     int fd, ret;
-    LINE confdir, infofile;
+    LINE confdir;
+    char infofile[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     char *buf, uidbuf[20];
 
     ret = -1;
@@ -780,7 +787,7 @@ parse_survey_line(char *lin)
 static int
 input_survey_quest(LINE lin, LINE reply, int qtype, int flag)
 {
-    char *s, *s2;
+    char *s, *s2 = NULL;  /* initialized to NULL to avoid maybe-uninitialized warning, modified on 2025-07-12, PL */
     long n1 = 0, n2 = 0;
     int i = 0, j = 0, t, ret;
 

--- a/survreport.c
+++ b/survreport.c
@@ -87,7 +87,8 @@ main(int argc, char *argv[])
         th->comment_num = num;
         th->comment_conf = 0;
         strcpy(tmp, MSG_REPORT);
-        strncat(tmp, th->subject, LINE_LEN - strlen(MSG_REPORT) - strlen(MSG_SUBJECT) - 4);
+     /* strncat(tmp, th->subject, LINE_LEN - strlen(MSG_REPORT) - strlen(MSG_SUBJECT) - 4); */
+        strlcat(tmp, th->subject, sizeof(tmp));  /* modified on 2025-07-13, PL */
         strcpy(th->subject, tmp);
         th->type = TYPE_TEXT;
 
@@ -117,14 +118,17 @@ post_survey_result(char *resultbuf, struct TEXT_HEADER * th, int conf, int ouid,
 {
     int fd, fdoutfile, usernum, i;
     char *buf, *oldbuf, *nbuf, *fbuf, *sb;
-    LINE conffile, confdir, textfile, home, cname, newline;
+    LINE cname, newline;
+    char conffile[256], confdir[256], textfile[256], home[256];  /* increased size to prevent truncation, modified on 2025-07-12, PL */
     struct CONF_ENTRY ce;
 
     if (conf < 0) {
         usernum = conf - (conf * 2);
         mbox_dir(usernum, home);
-        sprintf(conffile, "%s%s", home, MAILBOX_FILE);
-        sprintf(confdir, "%s/", home);
+     /* sprintf(conffile, "%s%s", home, MAILBOX_FILE); */
+        snprintf(conffile, sizeof(conffile), "%.200s%s", home, MAILBOX_FILE); /* 2025-07-13 PL */
+     /*	sprintf(confdir, "%s/", home); */
+        snprintf(confdir, sizeof(confdir), "%.200s/", home); /* 2025-07-13 PL */
         conf = 0;
     } else {
         strcpy(conffile, CONF_FILE);
@@ -156,7 +160,8 @@ post_survey_result(char *resultbuf, struct TEXT_HEADER * th, int conf, int ouid,
         return -1L;
     }
 
-    sprintf(textfile, "%s%ld", confdir, ce.last_text);
+ /* sprintf(textfile, "%s%ld", confdir, ce.last_text); */
+    snprintf(textfile, sizeof(textfile), "%.200s%ld", confdir, ce.last_text); /* 2025-07-13 PL */
 
     if ((fdoutfile = open_file(textfile, OPEN_QUIET | OPEN_CREATE)) == -1) {
         output("\n%s\n\n", MSG_ERRCREATET);

--- a/text.c
+++ b/text.c
@@ -38,9 +38,11 @@
 void
 display_header(struct TEXT_HEADER * th, int edit_subject, int type, int dtype, char *mailrec)
 {
-    LINE time_val, c, filename, fname, username;
+    LINE time_val, c, filename, username;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     int i, uid, right, nc, fd;
-    char *ptr, *tmp, *buf, *oldbuf;
+    char *tmp, *buf, *oldbuf;
+    char *ptr = NULL;   /* modified on 2025-07-12, PL */
     struct CONF_ENTRY *ce;
 
     if (mailrec && type && (th->author == 0)) {
@@ -125,7 +127,7 @@ display_header(struct TEXT_HEADER * th, int edit_subject, int type, int dtype, c
                         sprintf(fname, "%s/%d/%ld", SKLAFF_DB,
                             nc, th->comment_num);
                     } else {
-                        sprintf(fname, "%s/%ld", Mbox, th->comment_num);
+                        snprintf(fname, sizeof(fname), "%s/%ld", Mbox, th->comment_num);  /* modified on 2025-07-12, PL */
                     }
                     if ((fd = open_file(fname, OPEN_QUIET)) != -1) {
                         if ((buf = read_file(fd)) == NULL) {
@@ -519,8 +521,8 @@ mark_as_read(long text, int conf)
     struct CONFS_ENTRY cse;
     struct INT_LIST *int_list_next, *int_list_sav, *saved, *tmpsav;
     char *buf, *oldbuf, *nbuf;
-    LINE fname;
-
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
+    
     strcpy(fname, Home);
     strcat(fname, CONFS_FILE);
 
@@ -712,7 +714,7 @@ check_if_read(long text, int conf)
     int found, fd;
     struct CONFS_ENTRY cse;
     char *buf, *oldbuf;
-    LINE fname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
 
     strcpy(fname, Home);
     strcat(fname, CONFS_FILE);
@@ -770,8 +772,8 @@ next_text(int conf)
     long text, last, first, high;
     struct CONFS_ENTRY cse;
     char *buf, *oldbuf, *nbuf, *tmpbuf, saved;
-    LINE fname, textname, confsname;
-
+    LINE textname, confsname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     strcpy(fname, Home);
     strcat(fname, CONFS_FILE);
 
@@ -890,7 +892,7 @@ mark_as_unread(long text, int conf)
     int found, fd;
     struct CONFS_ENTRY cse;
     char *buf, *oldbuf, *nbuf;
-    LINE fname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
 
     struct INT_LIST
     *int_list_sav, *saved, *tmpsav;
@@ -1017,16 +1019,19 @@ mark_as_unread(long text, int conf)
 int
 display_text(int conf, long num, int stack, int dtype)
 {
-    LINE fname, username, home, emau, aname;
-    int fd, uid, type, endwritten, bypass, rot, survey_flag;
+    LINE username, home, emau, aname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
+    int fd, uid, type, endwritten, bypass, rot;
+    int survey_flag = 0;  /* initialized to avoid maybe-uninitialized warning, modified on 2025-07-12, PL */
     int survey_valid, quest;
-    char *buf, *oldbuf, *ptr;
+    char *buf, *oldbuf;
+    char *ptr = NULL;   /* modified on 2025-07-12, PL */
     struct TEXT_ENTRY te, te2;
     struct TEXT_HEADER *th;
     struct TEXT_BODY *tb;
     struct COMMENT_LIST *cl, *tmpcl, *savedcl;
-    char *survey_reply;
-
+    char *survey_reply = NULL;  /* modified on 2025-07-12, PL */
+    
     rot = Rot13;
     Rot13 = 0;
     if (num == 0) {
@@ -1263,7 +1268,8 @@ long
 parse_text(char *args)
 {
     long textnum;
-    LINE fname, home, tmpstr, tmpstr2;
+    LINE home, tmpstr, tmpstr2;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     int fd, uid, right;
     char *buf, *oldbuf;
     struct TEXT_ENTRY te;
@@ -1374,7 +1380,7 @@ parse_text(char *args)
 int
 stack_text(long num)
 {
-    LINE fname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     int fd;
     char *buf, *oldbuf;
     struct TEXT_ENTRY te;
@@ -1437,7 +1443,7 @@ stack_text(long num)
 int
 tree_top(long text)
 {
-    LINE fname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     int fd;
     long top;
     char *buf, *oldbuf;
@@ -1487,8 +1493,10 @@ tree_top(long text)
 int
 list_subj(char *str)
 {
-    LINE subject, author, fname;
-    char *buf, *oldbuf, *ptr2, *ptr3, *ptr4, sav, c;
+    LINE subject, author;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
+    char *buf, *oldbuf, *ptr3, *ptr4, sav, c;
+    char *ptr2 = NULL;   /* modified on 2025-07-12, PL */
     long firsttext, current_text;
     int dot_count, wait_count, strlgth, xit, from, fd;
     struct TEXT_ENTRY te;
@@ -1515,7 +1523,8 @@ list_subj(char *str)
         if (Current_conf) {
             sprintf(fname, "%s/%d/%ld", SKLAFF_DB, Current_conf, current_text);
         } else {
-            sprintf(fname, "%s/%ld", Mbox, current_text);
+        /* sprintf(fname, "%s/%ld", Mbox, current_text); */
+           snprintf(fname, sizeof(fname), "%s/%ld", Mbox, current_text);  /* modified on 2025-07-12, PL */
         }
         if ((fd = open_file(fname, OPEN_QUIET)) != -1) {
             if ((buf = read_file(fd)) == NULL) {
@@ -1677,7 +1686,7 @@ age_to_textno(long age)
     int fd;
     struct TEXT_ENTRY te;
     struct TEXT_HEADER *th;
-    LINE fname;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */;
 
     now = time(NULL);
 
@@ -1689,8 +1698,9 @@ age_to_textno(long age)
         if (Current_conf) {
             sprintf(fname, "%s/%d/%ld", SKLAFF_DB, Current_conf, current_text);
         } else {
-            sprintf(fname, "%s/%ld", Mbox, current_text);
-        }
+         /* sprintf(fname, "%s/%ld", Mbox, current_text); */   
+            snprintf(fname, sizeof(fname), "%s/%ld", Mbox, current_text);  /* modified on 2025-07-12, PL */
+}
         if ((fd = open_file(fname, OPEN_QUIET)) != -1) {
             if ((buf = read_file(fd)) == NULL) {
                 sys_error("list_subj", 1, "read_file");
@@ -1729,7 +1739,7 @@ save_text(char *fname, struct TEXT_HEADER * th, int conf)
 {
     int fd, fdinfile, fdoutfile, usernum, oldconf, ml;
     char *buf, *oldbuf, *nbuf, *inbuf, *fbuf;
-    LINE conffile, confdir, textfile, home;
+    char conffile[256], confdir[256], textfile[256], home[256];  /* increased size to prevent truncation, modified on 2025-07-12, PL */ 
     struct CONF_ENTRY ce;
 
     oldconf = conf;
@@ -1738,8 +1748,10 @@ save_text(char *fname, struct TEXT_HEADER * th, int conf)
         usernum = conf - (conf * 2);
         ml = usernum;
         mbox_dir(usernum, home);
-        sprintf(conffile, "%s%s", home, MAILBOX_FILE);
-        sprintf(confdir, "%s/", home);
+     /* sprintf(conffile, "%s%s", home, MAILBOX_FILE); */ // Original code
+	snprintf(conffile, sizeof(conffile), "%.200s%s", home, MAILBOX_FILE);  /* modified on 2025-07-12, PL */
+     /* sprintf(confdir, "%s/", home); */ // Original code
+        snprintf(confdir, sizeof(confdir), "%.252s/", home); /* modified on 2025-07-12, PL */
         conf = 0;
     } else {
         strcpy(conffile, CONF_FILE);
@@ -1771,7 +1783,8 @@ save_text(char *fname, struct TEXT_HEADER * th, int conf)
         return -1L;
     }
 
-    sprintf(textfile, "%s%ld", confdir, ce.last_text);
+ /* sprintf(textfile, "%s%ld", confdir, ce.last_text); */
+    snprintf(textfile, sizeof(textfile), "%.240s%ld", confdir, ce.last_text); /* modified on 2025-07-12, PL */
 
     if ((fdoutfile = open_file(textfile, OPEN_QUIET | OPEN_CREATE)) == -1) {
         output("\n%s\n\n", MSG_ERRCREATET);
@@ -1855,7 +1868,8 @@ save_text(char *fname, struct TEXT_HEADER * th, int conf)
             return -1L;
         }
 
-        sprintf(textfile, "%s%ld", confdir, ce.last_text);
+     /* sprintf(textfile, "%s%ld", confdir, ce.last_text); */
+        snprintf(textfile, sizeof(textfile), "%.240s%ld", confdir, ce.last_text); /* modified on 2025-07-12, PL */
 
         if ((fdoutfile = open_file(textfile,
                     OPEN_QUIET | OPEN_CREATE)) == -1) {
@@ -1986,7 +2000,7 @@ free_text_entry(struct TEXT_ENTRY * te)
 long
 save_mailcopy(char *rec, char *subject, char *inbuf)
 {
-    LONG_LINE conffile, confdir, textfile, copymsg;
+    char conffile[256], confdir[256], textfile[256], copymsg[256];  /* promoted to 256 to avoid truncation, modified on 2025-07-12, PL */
     char *buf, *oldbuf, *nbuf, *fbuf, *ptr;
     int fd, fd2;
     struct TEXT_HEADER th;
@@ -2016,7 +2030,8 @@ save_mailcopy(char *rec, char *subject, char *inbuf)
         return -1L;
     }
 
-    sprintf(textfile, "%s%ld", confdir, ce.last_text);
+ /* sprintf(textfile, "%s%ld", confdir, ce.last_text); */
+    snprintf(textfile, sizeof(textfile), "%.240s%ld", confdir, ce.last_text); /* modified on 2025-07-12, PL */
 
     if ((fd2 = open_file(textfile, OPEN_QUIET | OPEN_CREATE)) == -1) {
         output("\n%s\n\n", MSG_ERRCREATET);
@@ -2199,7 +2214,9 @@ int2ms(int i, char c[4])
 int
 display_survey_result(int conf, long num)
 {
-    LINE fname, username, confdir, resfile, home, time_val, c;
+    LINE username, confdir, home, time_val, c;
+    char fname[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
+    char resfile[128];  /* increased from LINE to avoid overflow, modified on 2025-07-12, PL */
     int fd, n, i;
     char *buf, *oldbuf, *s, *s2;
     struct TEXT_ENTRY te;


### PR DESCRIPTION
This commit addresses all remaining compile-time warnings under -Wall -Wextra -Wconversion -Werror.

- Uses snprintf/strlcpy instead of sprintf/strncpy
- Promotes selected buffers to 256 bytes
- Format strings capped to avoid truncation
- Maintains legacy behavior and 80x24 assumptions
- Tested on FreeBSD and Debian

Each change is tagged with a comment like: /* modified on 2025-07-12, PL */