### PR TITLE
Get Nethack up and running! (+ small language file fix)

### DIFF
--- a/command_list.c
+++ b/command_list.c
@@ -53,6 +53,7 @@ const struct COMMAND_ENTRY command_list[] = {
     { "cmd_mod_sig", cmd_mod_sig, },
     { "cmd_mod_timeout", cmd_mod_timeout, },
     { "cmd_my", cmd_my, },
+    { "cmd_nethack", cmd_nethack, },
     { "cmd_next_comment", cmd_next_comment, },
     { "cmd_next_conf", cmd_next_conf, },
     { "cmd_next_text", cmd_next_text, },

--- a/etc/parse.eng
+++ b/etc/parse.eng
@@ -88,6 +88,7 @@ Write (article):cmd_post_text:Write a new article in a conference
 Yell:cmd_yell:Same as 'shout'
 I:cmd_I:Tell everyone how you are
 (Make) survey:cmd_post_survey:Make a survey in the current conference
+Nethack:cmd_nethack:Play Nethack
 
 ?:cmd_help:Same as 'List commands'
 +:cmd_next_conf:Same as 'Next conference'

--- a/etc/parse.swe
+++ b/etc/parse.swe
@@ -98,6 +98,7 @@ Visa ol{sta (texter):cmd_reclaim_unread:Ol{smarkerar dina ol{sta texter direkt.
 [ndra plan:cmd_mod_sig:[ndra din plan-fil
 [ndra timeout:cmd_mod_timeout:[ndra tid f|r inaktivitetsutloggning
 [ndra uppstartskommandon:cmd_mod_login:[ndra vilka kommandon som k|rs vid login
+Nethack:cmd_nethack:Spela nethack
 
 ?:cmd_help:Synonymt med 'Lista kommandon'
 +:cmd_next_conf:Synonymt med '(G} till) n{sta m|te'

--- a/lang.h
+++ b/lang.h
@@ -690,6 +690,7 @@
 #define MSG_CPY2	"Copyright (C) 1993-1994  Torbj|rn B}}th, Peter Forsberg, Peter Lindberg,\n"
 #define MSG_CPY3	"                         Odd Petersson, Carl Sundbom.\n"
 #define MSG_CPY4	"QWK extensions (C) 1994  Daniel Gr|njord\n\n"
+#define MSG_CPY4a	"Surveys (C) 1996         Olof Runborg\n\n" /* Missing language strings made the english binary crash, now fixed 2025-07-14 PL */
 #define MSG_CPY5	"Program dedicated to the memory of Staffan Bergstr|m.\n\n"
 #define MSG_CPY6	"SklaffKOM comes with ABSOLUTELY NO WARRANTY. This is free software, \n"
 #define MSG_CPY7	"and you are welcome to redistribute it under certain conditions.\n\n"

--- a/sklaff.h
+++ b/sklaff.h
@@ -379,6 +379,7 @@ int cmd_list_yells(char *);
 int cmd_post_survey(char *);
 int cmd_read_last_text(char *);
 int cmd_reclaim_unread(char *);
+int cmd_nethack(char *);
 
 /* admin.c */
 


### PR DESCRIPTION
More or less hidden in the source code is the ability to load the "classic" console game "Nethack" as a door in Sklaffkom. 

The function (cmd_nethack) was already in commands.c, working out of the box as long as the nethack binary was installed in /usr/local/bin.

All it took was to add the command to call cmd_nethack in the following 4 files (as you would for adding any command in sklaffkom) :

```
sklaff.h
command_list.c
etc/parse.eng
etc/parse.swe
```
I did, however, add error checks and made the function smart enough to do a which-lookup in case the path still wasn't right.

Default location for FreeBSD is /usr/local/bin/nethack , and for Debian / Ubuntu /usr/games/nethack. You can adjust this path in commands.c around line 4827, but it should start regardless, as long as you remember to install the game :

Debian / Ubuntu : sudo apt install nethack-console
FreeBSD : sudo pkg install nethack36-3.6.7_1 (as of now)

This opens up a world of possibilites, and please count on dropfile support being added soon + a more convenient way to add more doors 😇 (without repeating the same code blocks over and over).

If approved we should also update the installation docs for sklaffkom, to encourage sysops to also install nethack. Or even include the source and build it in the Makefile - I don't know, haven't read the license yet ;).

I also found a missing language string in English, and added it to this commit while I was at it.