### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CFLAGS = $(SKLAFFFLAGS) -O2 -g -pipe -Wall -Werror
 #LIBS=-lsklaff -ltermcap -lelf -lm
 
 # uncomment for BSD/SUNOS/LINUX/ULTRIX
-LIBS=-lsklaff -lm
+LIBS=-lsklaff -lbsd -lm
 
 # uncomment for SOLARIS
 #CFLAGS=-g -I/usr/ucbinclude


### PR DESCRIPTION
Addition of the -lbsd library when compiling for Linux (for crossplatform compatibility).

Linux users need to install libbsd-dev through their package manager, for example :

sudo apt install libbsd-dev

TODO : Add to documentation