### PR TITLE
Fixes for upload,download,list files etc

### DIFF
--- a/lib/hostname.c
+++ b/lib/hostname.c
@@ -112,7 +112,9 @@ get_hostname(void)
         strcpy(my_host, "N/A");
         return my_host;
     }
-    strlcpy(tmp, ptr, sizeof(my_host));
+/*  strlcpy(tmp, ptr, sizeof(my_host)); */
+    strlcpy(tmp, ptr, sizeof(tmp)); /* New code for Ubuntu 24.04 compatibility, replaces above line */
+
     ptr = strchr(tmp + 1, '/');
     ptr++;
     uf = open(UTMP_REC, O_RDONLY);

--- a/sklaff.h
+++ b/sklaff.h
@@ -288,6 +288,7 @@ char *real_string(char *);
 char *reorder_name(char *, char *);
 char *prog_name(char *);
 char *mbox_dir(int, char *);
+const char *safe_str(const char *s); /* 2025-07-26 PL */
 
 /* Debugging */
 /* void *my_malloc (size_t); */


### PR DESCRIPTION
Here we have a huge commit that should fix all issues related to file transfers, as mentioned in issue #9.

The whole upload/download and list-files mechanisms were broken in so many places it took me many late nights to figure all of this out.

Quite big changes this time so please help me test and report any weirdness.

* Fixes long-standing "(null") bug in file listings on FreeBSD
* Fixes so that sklaffkom now is looking for the ".index" file (for file listings) in correct directories
* We now have a "safe_str()" helper to prevent empty/NULL strings ever being passed to output()
* output() now uses vsnprintf() instead of vsprintf which is safer (buffer overflow prevention)
* The calls to lrz and lsz are now done in a more elegant way to avoid "garbage on command line" complains from lrz and lsz.

Unfortunately lrz and lsz will most likely still complain about setuid. The best solution I could come up with was to remove the setuid checks from the source and re-compile lrz and lsz.

If you don't want to start from scratch please clone my lrzsz-fork :
https://github.com/loppanloppis/lrzsz.git , build scripts for Linux and FreeBSD are in the "sklaffkom-mod" directory.

As an option, I also provide drop-in binaries for Linux (64bit) and FreeBSD (32bit) here :
https://sklaff.dev/files/

If we think this is an acceptable solution (I really can't think of any other way) we should add the above instructions to the installation instructions at some point ;).

Oh, and here are the settings that works for me :

```
#define UPLOADPRGM      "/usr/local/bin/lrz"
#define ULOPT1          "-Eq"
#define DOWNLOADPRGM    "/usr/local/bin/lsz"
#define DLOPT1          "-Eq"
#define DLOPT2          ""
#define DLOPT3          ""

```
Perhaps we should update sklaff.h and provide these settings by default?

Cheers

