### PR TITLE
Fix for serious bug in the English version

### DIFF
--- a/lang.h
+++ b/lang.h
@@ -382,7 +382,7 @@
 /* flag.c */
 
 #define MSG_FLAG0	"ibm-pc"
-#define MSG_FLAG0N	2
+#define MSG_FLAG0N	2 	/*ambiguity check - how many chars required to make flag name unique /Detective PL 2025-07-30 */
 #define MSG_FLAG0F	"IBM-PC (teckenupps{ttning)"
 #define MSG_FLAG1	"iso 8859-1"
 #define MSG_FLAG1N	2
@@ -658,6 +658,14 @@
 
 /* lib/output.c */
 
+#ifdef LINUX
+/* MSG_MORE is defined in Linux socket API. First ensure it is
+   included, and then undefine it so we can re-define it. */
+# include <sys/socket.h>
+# if defined(MSG_MORE)
+#  undef MSG_MORE
+# endif
+#endif
 #define MSG_MORE 	"-More-"
 
 /* lib/time_string.c */
@@ -881,6 +889,8 @@
 #define MSG_EMFROM	"From: "
 #define MSG_EMFROM2	"FROM: "
 #define MSG_EMFROM3	"from: "
+#define MSG_EMFROM4     "From " /* Newer mailprgs may need this, PL 2025-07-30 */
+#define MSG_EMFROM5     "from " /* Newer mailprgs may need this, PL 2025-07-30 */
 #define MSG_EMRETURN	"Return-Path: "
 #define MSG_PRIO	"given high priority."
 #define MSG_DEPRIO	"given low priority."
@@ -1226,16 +1236,18 @@
 /* sklaffacct.c */
 
 #define MSG_INNAME	"First and last name    : "
-#define MSG_INLOGIN	"login (6-8 characters) : "
+#define MSG_INLOGIN	"Login name             : "
 #define MSG_INPASSWD	"Password               : "
 #define MSG_INMODEM	"Modempool-access       : "
 #define MSG_INTELE	"Voice telephone	: "
+#define MSG_INPOST      "E-mail address         : "
 #define MSG_ACCAPP	"Account application: "
 #define MSG_INSNAME	"Name     : "
 #define MSG_INSLOGIN	"\nlogin    : "
 #define MSG_INSPASSWD	"\npasswd   : "
 #define MSG_INSMODEM	"\nModem    : "
 #define MSG_INSTELE	"\nTelephone: "
+#define MSG_INSPOST     "\nE-mail : "
 #define MSG_APPLIED	"Your application har been posted.\nWelcome back.\n\n"
 #define MSG_UIDINUSE	"login-name in use by another user."
 

--- a/lib/time_string.c
+++ b/lib/time_string.c
@@ -48,7 +48,7 @@ char *time_string(time_t in_time, char *out_time, int show_date)
     struct tm ts, ts_now;
     time_t now;
     int out_day, comp_year;
-    char day_string[9];
+    char day_string[16]; /* Crucial bugfix that made English sklaffkom crash during certain weekdays :D 2025-07-31 PL */
 
     memcpy(&ts, localtime(&in_time), sizeof(struct tm));
     if (show_date) {


### PR DESCRIPTION
One late night when I was working with the English version of Sklaffkom, all of a sudden it would give segfault when launching, while display_welcome() to the user, and I could not for the life of me figure out what I had done wrong this time.

I looked over my recent code changes and reverted them, but it did not help.

The debugger told me the problem lies in lib/time_string.c , a file I've never been in before.

Spent some more time learning gdb debugging until I finally figured it out.

In time_string.c we have :

char day_string[9];

It's a string that stores the name of the weekday (Monday, Tuesday, Wednesday etc...).

The time was just over midnight and I was about to give up... When I realized...

Sklaffkom wanted to tell me the last time I logged in was on Wednesday, and today (after midnight) it's Thursday.

The word Wednesday is 9 characters long. Tuesday on the other hand is only 7 characters (so launching Sklaffkom before midnight on a Wednesday was not an issue). One may think 9 chars would be enough even for the English words but we need to reserve one extra byte for null also.

In Swedish, 9 chars are enough for all days of the week.

I wonder how long this bug has been there?

I increased the day_string buffer to [16] which gives plenty of headroom 😅.

I also found some missing English language strings in lang.h that I now added as well.