### PR TITLE
small ftntoss and mailtoss fixes

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -905,6 +905,12 @@ if (st_type == STATUS_EXTERNAL)
             case NEWS_CONF:
                 output("%s\n", MSG_NEWS2);
                 break;
+            case FTN_CONF:
+                output("%s\n", MSG_FTN);
+                break;
+            default:
+                output("%s\n", MSG_UNKNOWNU);
+                break;
             }
             if (ce->comconf)
                 output("%s%s\n", MSG_CONFCOM,

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <sys/types.h>
 #include <pwd.h> /* modified on 2026-06-14, PL */
 
 #define FTNTOSS_LOCKFILE "/tmp/ftntoss.lock" /* modified on 2026-06-11, PL */
@@ -193,6 +194,8 @@ static void append_to_dynbuf(char **buf, size_t *cap, size_t *len,
     const char *text);
 
 static void sklaff_version_no_build(char *out, size_t outsz);
+
+static void ftntoss_notify_all_processes(int sig); /* modified on 2026-07-05, PL */
 
 static void
 sklaff_version_no_build(char *out, size_t outsz)
@@ -1895,6 +1898,47 @@ strip_eol(char *s)
     }
 }
 
+static void
+ftntoss_notify_all_processes(int sig)
+{
+    FILE *fp;
+    char line[512];
+    char *p;
+    char *end;
+    long pid;
+
+    /*
+     * ftntoss is linked as a small standalone tool.  Do not use
+     * notify_all_processes() from msg.c or get_active_entry() from buf.c
+     * here, because those objects pull in large parts of the interactive
+     * SklaffKOM binary.
+     *
+     * ACTIVE_FILE format:
+     * uid:pid:login_time:avail:from:tty:...
+     *
+     * modified on 2026-07-05, PL
+     */
+    fp = fopen(ACTIVE_FILE, "r");
+    if (fp == NULL)
+        return;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        p = strchr(line, ':');
+        if (p == NULL)
+            continue;
+
+        p++;
+        pid = strtol(p, &end, 10);
+        if (p == end || *end != ':')
+            continue;
+
+        if (pid > 1)
+            kill((pid_t)pid, sig);
+    }
+
+    fclose(fp);
+}
+
 static int
 read_skom_export_text(int confnum, long textnum, long *out_uid,
     long *out_time, long *out_com, char *subject, size_t subjectsz,
@@ -2483,6 +2527,14 @@ import_one_ftn(const char *area, const char *filename)
         goto cleanup;
     }
 
+    /*
+     * Wake active SklaffKOM sessions so their prompts notice newly imported
+     * FTN text, matching newstoss/mailtoss behaviour.
+     *
+     * modified on 2026-06-24, PL
+     */
+    ftntoss_notify_all_processes(SIGNAL_NEW_TEXT); /* modified on 2026-07-05, PL */
+
     printf("\nftntoss import-one done\n");
     printf("Imported: SklaffKOM text %ld\n", imported_text);
 
@@ -2723,6 +2775,15 @@ import_all_ftn(const char *area, int include_unsafe)
     printf("Orphan replies:   %ld parent not found\n", orphan);
     printf("Re without REPLY: %ld skipped\n", skipped_re_without_reply);
     printf("Failed:           %ld\n", failed);
+
+    /*
+     * Wake active SklaffKOM sessions once after a successful import batch.
+     *
+     * modified on 2026-06-24, PL
+     */
+    if (imported > 0)
+    ftntoss_notify_all_processes(SIGNAL_NEW_TEXT); /* modified on 2026-07-05, PL */
+
     rc = failed ? -1 : 0;
 
 cleanup:

--- a/lang.h
+++ b/lang.h
@@ -107,6 +107,7 @@
 #define MSG_MINUTES	"minuter."
 #define MSG_ONEMIN	"en minut."
 #define MSG_WARNING	"Om en minut blir jag utloggad pga inaktivitet!"
+#define MSG_FTN		"ftn"
 
 /* bbslink.c */
 
@@ -822,6 +823,7 @@
 #define MSG_MINUTES	"minutes."
 #define MSG_ONEMIN	"one minute."
 #define MSG_WARNING	"Inactivity logout in one minute!"
+#define MSG_FTN		"ftn"
 
 /* bbslink.c */                                                                 
                                                                                 
@@ -1024,7 +1026,6 @@
 #define MSG_FILE_DB_ER	"File DB configuration error, speak with your SysOp!"
 #define MSG_ULPRGMERROR "Upload program missing or can't be run. Contact your SysOp!"
 #define MSG_FILES_OFF 	"File transfers are not configured on this system."
-#define MSG_FILES_OFF 	"Filöverföringar är inte konfigurerade på detta system."
 #define MSG_OPEN_C_E	"Error : failed to open confxtra. Contact your SysOp."
 #define MSG_READ_C_E	"Error : failed to read confxtra. Contact your SysOp."
 #define MSG_WRITE_C_E	"Error : failed to write confxtra. Contact your SysOp."

--- a/mailtoss.c
+++ b/mailtoss.c
@@ -36,6 +36,27 @@
 #include <errno.h>   /* ENOENT for graceful "no mail" exit (2025-08-13, PL) */
 #include <stdarg.h>  /* verbose status output (2026-05-13, PL) */
 
+#define MAILTOSS_WRAP_COL 78 /* modified on 2026-06-23, PL */
+
+/*
+ * Keep raw spool copies before truncation when debugging mail import.
+ * Leave undefined for normal production runs.
+ *
+ * Debug messages are saved in your SKLAFFDIR/var/mailtoss-debug directory.
+ * You need to create this directory manually with appropriate permissions.
+ *
+ * Example :
+ * mkdir -p /usr/local/sklaff/var/mailtoss-debug
+ * chown sklaff:sklaff /usr/local/sklaff/var/mailtoss-debug
+ * chmod 700 /usr/local/sklaff/var/mailtoss-debug
+ *
+ * modified on 2026-07-05, PL
+ */
+
+/* #define MAILTOSS_DEBUG */
+
+static char *wrap_mail_body_for_skom(const char *body); /* modified on 2026-06-23, PL */
+
 static int
 hexval(int c)
 {
@@ -112,6 +133,95 @@ mt_status(const char *fmt, ...)
     vprintf(fmt, ap);
     va_end(ap);
     printf("\n");
+}
+
+static char *
+wrap_mail_body_for_skom(const char *body)
+{
+    const char *line;
+    char *out;
+    char *d;
+    size_t len;
+
+    if (body == NULL)
+        return NULL;
+
+    len = strlen(body);
+
+    /*
+     * Wrapping can only add one newline per MAILTOSS_WRAP_COL characters.
+     * Allocate generously so the code stays simple and avoids old fixed-size
+     * line buffers.
+     *
+     * modified on 2026-06-23, PL
+     */
+    out = malloc((len * 2) + 2);
+    if (out == NULL)
+        return NULL;
+
+    d = out;
+    line = body;
+
+    while (*line != '\0') {
+        const char *eol;
+        size_t linelen;
+
+        eol = line;
+        while (*eol != '\0' && *eol != '\r' && *eol != '\n')
+            eol++;
+
+        linelen = (size_t)(eol - line);
+
+        while (linelen > MAILTOSS_WRAP_COL) {
+            size_t cut = MAILTOSS_WRAP_COL;
+            size_t j;
+
+            /*
+             * Prefer word wrapping for ordinary text.  If there is no usable
+             * whitespace, hard-wrap instead; this prevents long mail lines
+             * from being clipped by older SklaffKOM display paths.
+             *
+             * modified on 2026-06-23, PL
+             */
+            for (j = MAILTOSS_WRAP_COL; j > 0; j--) {
+                if (line[j - 1] == ' ' || line[j - 1] == '\t') {
+                    if (j > 1)
+                        cut = j - 1;
+                    break;
+                }
+            }
+
+            memcpy(d, line, cut);
+            d += cut;
+            *d++ = '\n';
+
+            line += cut;
+            linelen -= cut;
+
+            while (linelen > 0 && (*line == ' ' || *line == '\t')) {
+                line++;
+                linelen--;
+            }
+        }
+
+        if (linelen > 0) {
+            memcpy(d, line, linelen);
+            d += linelen;
+        }
+
+        if (*eol == '\r' && eol[1] == '\n')
+            eol++;
+
+        if (*eol == '\r' || *eol == '\n') {
+            *d++ = '\n';
+            line = eol + 1;
+        } else {
+            line = eol;
+        }
+    }
+
+    *d = '\0';
+    return out;
 }
 
 static int
@@ -214,7 +324,29 @@ main(int argc, char *argv[])
 
     mt_status("%d nya mail identifierade.", identified);
 
-    if (truncate_spool(mbox) == -1) {
+#ifdef MAILTOSS_DEBUG
+    /*
+	* Debug: keep a copy of every raw mail spool before mailtoss truncates it.
+	 * This makes intermittent MIME/wrapping import bugs reproducible.
+	 *
+	* modified on 2026-06-23, PL
+	*/
+	{
+        char dbgfile[512];
+        time_t now;
+
+        now = time(NULL);
+        snprintf(dbgfile, sizeof(dbgfile),
+        "%s/var/mailtoss-debug/%s-%ld-%d.mbox",
+        SKLAFFDIR, argv[1], (long)now, getpid());
+
+        if (copy_file(mbox, dbgfile) == -1)
+            mt_status("kunde inte spara debugkopia av spoolen: %s", dbgfile);
+        else
+            mt_status("debugkopia av spoolen sparad: %s", dbgfile);
+	}
+#endif
+	if (truncate_spool(mbox) == -1) {
         mt_status("kunde inte trunkera spoolen: %s", strerror(errno));
         free(oldbuf);
         exit(1);
@@ -277,7 +409,7 @@ send_mail(int uid, char *mbuf, int ouid, int ogrp)
     struct TEXT_HEADER th;
     int fd, fdo;
 	char *buf, *oldbuf, *nbuf = NULL, *ptr, *tmp, *fbuf;
-	char *plainbuf = NULL, *decodedbuf = NULL, *sf7body = NULL, *storebuf = NULL; 	/* added 2026-05-28 for better looking e-mail imports */
+	char *plainbuf = NULL, *decodedbuf = NULL, *sf7body = NULL, *wrappedbody = NULL, *storebuf = NULL; 	/* added 2026-05-28 for better looking e-mail imports */
 	const char *hdr_end;															/* added 2026-05-28 for better looking e-mail imports */
 	size_t header_len, store_len;													/* added 2026-05-28 for better looking e-mail imports */
 
@@ -338,9 +470,9 @@ send_mail(int uid, char *mbuf, int ouid, int ogrp)
     }
 
  	if (mail_has_base64(mbuf)) {
-    	decodedbuf = mail_base64_decode_dup(plainbuf);
+        decodedbuf = mail_base64_decode_dup(plainbuf);
 	} else if (mail_has_quoted_printable(mbuf)) {
-    	decodedbuf = mail_qp_decode_dup(plainbuf);
+        decodedbuf = qp_decode_dup(plainbuf); /* modified on 2026-06-23, PL */
 	} else {
     	decodedbuf = strdup(plainbuf);
 	}
@@ -359,6 +491,14 @@ send_mail(int uid, char *mbuf, int ouid, int ogrp)
         return -1;
     }
 
+    wrappedbody = wrap_mail_body_for_skom(sf7body); /* modified on 2026-06-23, PL */
+    free(sf7body);
+
+    if (wrappedbody == NULL) {
+        sys_error("send_mail", 1, "wrap_mail_body_for_skom");
+        return -1;
+    }
+
     /*
      * Preserve original headers, but replace raw MIME body with clean SF7 text.
      */
@@ -374,10 +514,10 @@ send_mail(int uid, char *mbuf, int ouid, int ogrp)
     }
 
     if (header_len > 0) {
-		store_len = header_len + 2 + strlen(sf7body) + 1;
+		store_len = header_len + 2 + strlen(wrappedbody) + 1;
         storebuf = malloc(store_len);
         if (storebuf == NULL) {
-            free(sf7body);
+            free(wrappedbody);
             sys_error("send_mail", 1, "malloc storebuf");
             return -1;
         }
@@ -385,17 +525,17 @@ send_mail(int uid, char *mbuf, int ouid, int ogrp)
         memcpy(storebuf, mbuf, header_len);
         storebuf[header_len] = '\0';
         strcat(storebuf, "\n\n");
-        strcat(storebuf, sf7body);
+        strcat(storebuf, wrappedbody);
     } else {
-        storebuf = strdup(sf7body);
+        storebuf = strdup(wrappedbody);
         if (storebuf == NULL) {
-            free(sf7body);
+            free(wrappedbody);
             sys_error("send_mail", 1, "strdup storebuf");
             return -1;
         }
     }
 
-    free(sf7body);
+    free(wrappedbody);
 
     th.size = 0;
     ptr = storebuf;


### PR DESCRIPTION
Small fixes in ftntoss and mailtoss :

* status (conference) now shows correct conference type for ftn conferences :

```
(Läsa) nästa text -> status fsx_gen

Namn:          FSX_GEN
Mötestyp:      ftn
Skapat:        17 Jun 2026 23:18 av Sklaffadmin
Antal texter:  387

(Läsa) nästa text -> 
```

* Experimental : when new ftn-messages are imported, users should now be notified, and the database updated accordingly with the new posts (before this fix, a user had to sign off and back in again to see the new ftn posts). I have not tested this enough, but I'm fairly confident this fix does not break other things, at the very least :).

* mailtoss improvements : We are now wrapping lines longer than 78 characters.. There's also a debug function implemented that is switched off by default. If you wish to enable, uncomment line 56 in mailtoss.c (define #MAILTOSS_DEBUG) and create the directories like so :

```
mkdir -p /usr/local/sklaff/var/mailtoss-debug                                
chown sklaff:sklaff /usr/local/sklaff/var/mailtoss-debug                     
chmod 700 /usr/local/sklaff/var/mailtoss-debug 
```

Next up is avoiding sf7 completely in incoming e-mails + proper handling of  html + netmail support (incoming / and outgoing)