### PR TITLE
ftntoss permission fixes (probably...)

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -78,16 +78,28 @@ set_prompt_storage_error(const char *path, const char *op)
 }
 
 static int
-check_prompt_readable_file(const char *path)
+check_prompt_open_file(const char *path, int flags, const char *op)
 {
     int fd;
 
-    fd = open(path, O_RDONLY);
+    fd = open(path, flags);
     if (fd == -1)
-        return set_prompt_storage_error(path, "open");
+        return set_prompt_storage_error(path, op);
 
     close(fd);
     return 0;
+}
+
+static int
+check_prompt_readable_file(const char *path)
+{
+    return check_prompt_open_file(path, O_RDONLY, "open");
+}
+
+static int
+check_prompt_writable_file(const char *path)
+{
+    return check_prompt_open_file(path, O_RDWR, "open rw");
 }
 
 static int
@@ -146,7 +158,11 @@ sklaff_storage_ok_for_prompt(void)
     Prompt_storage_path[0] = '\0';
     Prompt_storage_error[0] = '\0';
 
-    if (check_prompt_readable_file(CONF_FILE) == -1)
+    /*
+     * Many old SklaffKOM callers open CONF_FILE read/write even when they
+     * mainly read it.  Check O_RDWR here so the guard matches real use.
+     */
+    if (check_prompt_writable_file(CONF_FILE) == -1)
         return 0;
 
     if (check_prompt_db_tree(SKLAFF_DB) == -1)
@@ -159,8 +175,6 @@ sklaff_storage_ok_for_prompt(void)
 static void
 warn_prompt_storage_problem(void)
 {
-    LONG_LINE logmsg;
-
     if (Prompt_storage_warned)
         return;
 
@@ -172,15 +186,20 @@ warn_prompt_storage_problem(void)
         snprintf(Prompt_storage_error, sizeof(Prompt_storage_error),
             "open: %s", strerror(errno));
 
-    snprintf(logmsg, sizeof(logmsg),
-        "storage check before prompt failed: %s (%s)",
-        Prompt_storage_path, Prompt_storage_error);
-    debuglog(logmsg, 1);
+    /*
+     * Keep these as separate log entries.  Building one long formatted
+     * string can trigger -Wformat-truncation with -Werror on fortified
+     * builds, even though the user-facing message below is fine.
+     */
+    debuglog("storage check before prompt failed", 1);
+    debuglog(Prompt_storage_path, 1);
+    debuglog(Prompt_storage_error, 1);
 
     output("\n\nInternt lagringsfel: SklaffKOM kan inte läsa databasen.\n");
     output("Kontakta SysOP. Teknisk detalj: %s (%s)\n\n",
         Prompt_storage_path, Prompt_storage_error);
 }
+
 
 /*
  * display_prompt - displays default prompt
@@ -380,6 +399,20 @@ display_welcome(void)
         down_string(name);
         output_ansi_fmt("\n%s" CYAN " %s\n"DOT, "\n%s %s\n", MSG_LASTHERE, name);
     }
+
+    /*
+     * Several setup paths after the welcome text may touch CONF_FILE before
+     * display_prompt() gets a chance to run its storage guard.  If an external
+     * importer has replaced CONF_FILE with a root-owned file, fail here with
+     * a useful error instead of letting old code segfault later.
+     */
+    if (check_prompt_writable_file(CONF_FILE) == -1) {
+        warn_prompt_storage_problem();
+        sig_reset();
+        tty_reset();
+        exit(1);
+    }
+
     cstack = NULL;
     ustack = NULL;
     ustack2 = NULL;

--- a/admin.c
+++ b/admin.c
@@ -27,12 +27,160 @@
 
 #include <sys/stat.h>
 
+#include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <pwd.h>
 #include <signal.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "sklaff.h"
 #include "ext_globals.h"
+
+
+/*
+ * sklaff_storage_ok_for_prompt - cheap airbag before unread scans.
+ *
+ * The prompt code calls more_comment(), more_text() and more_conf().  Those
+ * functions walk the SklaffKOM database.  If an external tosser/importer has
+ * created root-owned or otherwise unreadable files under SKLAFF_DB/CONF_FILE,
+ * old SklaffKOM code may continue after failed open/read and crash.
+ *
+ * This guard does not fix the bad files.  It detects the common damage once
+ * per login, writes a useful debug message and lets the user reach a prompt
+ * instead of segfaulting.
+ *
+ * modified on 2026-07-09, PL
+ */
+
+static int Prompt_storage_checked = 0;
+static int Prompt_storage_ok = 1;
+static int Prompt_storage_warned = 0;
+static LONG_LINE Prompt_storage_path;
+static LINE Prompt_storage_error;
+
+static int
+set_prompt_storage_error(const char *path, const char *op)
+{
+    int e = errno;
+
+    if (path == NULL)
+        path = "(null)";
+    if (op == NULL)
+        op = "open";
+
+    snprintf(Prompt_storage_path, sizeof(Prompt_storage_path), "%s", path);
+    snprintf(Prompt_storage_error, sizeof(Prompt_storage_error),
+        "%s: %s", op, strerror(e));
+
+    return -1;
+}
+
+static int
+check_prompt_readable_file(const char *path)
+{
+    int fd;
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1)
+        return set_prompt_storage_error(path, "open");
+
+    close(fd);
+    return 0;
+}
+
+static int
+check_prompt_db_tree(const char *dir)
+{
+    DIR *dp;
+    struct dirent *de;
+    struct stat st;
+    LONG_LINE path;
+
+    dp = opendir(dir);
+    if (dp == NULL)
+        return set_prompt_storage_error(dir, "opendir");
+
+    while ((de = readdir(dp)) != NULL) {
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+            continue;
+
+        if (snprintf(path, sizeof(path), "%s/%s", dir, de->d_name) >=
+            (int)sizeof(path)) {
+            closedir(dp);
+            errno = ENAMETOOLONG;
+            return set_prompt_storage_error(dir, "path too long");
+        }
+
+        if (lstat(path, &st) == -1) {
+            closedir(dp);
+            return set_prompt_storage_error(path, "lstat");
+        }
+
+        if (S_ISDIR(st.st_mode)) {
+            if (check_prompt_db_tree(path) == -1) {
+                closedir(dp);
+                return -1;
+            }
+        } else if (S_ISREG(st.st_mode)) {
+            if (check_prompt_readable_file(path) == -1) {
+                closedir(dp);
+                return -1;
+            }
+        }
+    }
+
+    closedir(dp);
+    return 0;
+}
+
+static int
+sklaff_storage_ok_for_prompt(void)
+{
+    if (Prompt_storage_checked)
+        return Prompt_storage_ok;
+
+    Prompt_storage_checked = 1;
+    Prompt_storage_ok = 0;
+    Prompt_storage_path[0] = '\0';
+    Prompt_storage_error[0] = '\0';
+
+    if (check_prompt_readable_file(CONF_FILE) == -1)
+        return 0;
+
+    if (check_prompt_db_tree(SKLAFF_DB) == -1)
+        return 0;
+
+    Prompt_storage_ok = 1;
+    return 1;
+}
+
+static void
+warn_prompt_storage_problem(void)
+{
+    LONG_LINE logmsg;
+
+    if (Prompt_storage_warned)
+        return;
+
+    Prompt_storage_warned = 1;
+
+    if (Prompt_storage_path[0] == '\0')
+        snprintf(Prompt_storage_path, sizeof(Prompt_storage_path), "%s", CONF_FILE);
+    if (Prompt_storage_error[0] == '\0')
+        snprintf(Prompt_storage_error, sizeof(Prompt_storage_error),
+            "open: %s", strerror(errno));
+
+    snprintf(logmsg, sizeof(logmsg),
+        "storage check before prompt failed: %s (%s)",
+        Prompt_storage_path, Prompt_storage_error);
+    debuglog(logmsg, 1);
+
+    output("\n\nInternt lagringsfel: SklaffKOM kan inte läsa databasen.\n");
+    output("Kontakta SysOP. Teknisk detalj: %s (%s)\n\n",
+        Prompt_storage_path, Prompt_storage_error);
+}
 
 /*
  * display_prompt - displays default prompt
@@ -48,7 +196,15 @@ display_prompt(char *p, char *oldp, int type)
     if (Change_prompt) {
         Nextconf = -1;
         Nexttext = -1;
-        if (more_comment())
+        if (!sklaff_storage_ok_for_prompt()) {
+            warn_prompt_storage_problem();
+            Change_prompt = 0;
+            if (End_default) {
+                strcpy(p, MSG_ENDPROMPT);
+            } else {
+                strcpy(p, MSG_TIMEPROMPT);
+            }
+        } else if (more_comment())
             strcpy(p, MSG_REPLYPROMPT);
         else if (more_text())
             strcpy(p, MSG_TEXTPROMPT);

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -16,7 +16,9 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/types.h>
+#include <sys/stat.h> /* modified on 2026-07-09, PL */
 #include <pwd.h> /* modified on 2026-06-14, PL */
+#include <grp.h> /* modified on 2026-07-09, PL */
 
 #define FTNTOSS_LOCKFILE "/tmp/ftntoss.lock" /* modified on 2026-06-11, PL */
 #define FTN_WRAP_COL 78 /* modified on 2026-06-13, PL */
@@ -196,6 +198,10 @@ static void append_to_dynbuf(char **buf, size_t *cap, size_t *len,
 static void sklaff_version_no_build(char *out, size_t outsz);
 
 static void ftntoss_notify_all_processes(int sig); /* modified on 2026-07-05, PL */
+
+static int ftntoss_get_sklaff_ids(uid_t *uid, gid_t *gid); /* modified on 2026-07-09, PL */
+static int ftntoss_fix_fd_to_sklaff(FILE *fp, const char *path, mode_t mode); /* modified on 2026-07-09, PL */
+static int ftntoss_fix_fd_like_stat(FILE *fp, const char *path, const struct stat *st); /* modified on 2026-07-09, PL */
 
 static void
 sklaff_version_no_build(char *out, size_t outsz)
@@ -1898,6 +1904,148 @@ strip_eol(char *s)
     }
 }
 
+static int
+ftntoss_get_sklaff_ids(uid_t *uid, gid_t *gid)
+{
+    static int cached = 0;
+    static uid_t sklaff_uid;
+    static gid_t sklaff_gid;
+    struct passwd *pw;
+    struct group *gr;
+
+    if (uid == NULL || gid == NULL)
+        return -1;
+
+    if (!cached) {
+        pw = getpwnam("sklaff");
+        gr = getgrnam("sklaff");
+
+        if (pw == NULL || gr == NULL) {
+            fprintf(stderr,
+                "[ERROR] ftntoss: could not resolve user/group sklaff:sklaff\n");
+            fprintf(stderr,
+                "[ERROR] ftntoss: imported SklaffKOM files need owner sklaff\n");
+            return -1;
+        }
+
+        sklaff_uid = pw->pw_uid;
+        sklaff_gid = gr->gr_gid;
+        cached = 1;
+    }
+
+    *uid = sklaff_uid;
+    *gid = sklaff_gid;
+    return 0;
+}
+
+static int
+ftntoss_fix_fd_to_sklaff(FILE *fp, const char *path, mode_t mode)
+{
+    uid_t uid;
+    gid_t gid;
+    int fd;
+
+    if (fp == NULL || path == NULL)
+        return -1;
+
+    if (ftntoss_get_sklaff_ids(&uid, &gid) != 0)
+        return -1;
+
+    fd = fileno(fp);
+    if (fd == -1) {
+        perror("fileno");
+        return -1;
+    }
+
+    if (geteuid() == 0) {
+        if (fchown(fd, uid, gid) == -1) {
+            fprintf(stderr,
+                "[ERROR] ftntoss: fchown(%s, sklaff:sklaff) failed: %s\n",
+                path, strerror(errno));
+            return -1;
+        }
+    } else if (geteuid() != uid) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: %s was created while running as uid %ld\n",
+            path, (long)geteuid());
+        fprintf(stderr,
+            "[ERROR] ftntoss: run this command as root/sudo or as user sklaff, "
+            "otherwise SklaffKOM may not be able to read imported texts.\n");
+        return -1;
+    }
+
+    if (fchmod(fd, mode) == -1) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: fchmod(%s, %04o) failed: %s\n",
+            path, (unsigned)mode, strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+static int
+ftntoss_fix_fd_like_stat(FILE *fp, const char *path, const struct stat *st)
+{
+    uid_t uid;
+    gid_t gid;
+    int fd;
+    mode_t mode;
+
+    if (fp == NULL || path == NULL || st == NULL)
+        return -1;
+
+    if (ftntoss_get_sklaff_ids(&uid, &gid) != 0)
+        return -1;
+
+    fd = fileno(fp);
+    if (fd == -1) {
+        perror("fileno");
+        return -1;
+    }
+
+    /*
+     * rewrite_conf_last_text() writes a temporary CONF_FILE and renames it
+     * over the real one.  If ftntoss is run with sudo, the replacement must
+     * not accidentally become root:root 0600, because SklaffKOM later reads
+     * CONF_FILE while running as user sklaff.
+     *
+     * Always force owner to sklaff.  Preserve the existing group when we have
+     * privileges, because many stock files are sklaff:root.  When running
+     * directly as sklaff, preserving the root group may not be possible, but
+     * owner sklaff plus mode 0600 is enough for the live BBS to read the file.
+     *
+     * modified on 2026-07-09, PL
+     */
+    if (geteuid() == 0) {
+        if (fchown(fd, uid, st->st_gid) == -1) {
+            fprintf(stderr,
+                "[ERROR] ftntoss: fchown(%s, sklaff:%ld) failed: %s\n",
+                path, (long)st->st_gid, strerror(errno));
+            return -1;
+        }
+    } else if (geteuid() != uid) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: cannot safely rewrite %s as uid %ld; "
+            "expected user sklaff\n",
+            path, (long)geteuid());
+        fprintf(stderr,
+            "[ERROR] ftntoss: run this command as root/sudo or as the "
+            "SklaffKOM owner user.\n");
+        return -1;
+    }
+
+    mode = st->st_mode & 07777;
+    if (fchmod(fd, mode) == -1) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: fchmod(%s, %04o) failed: %s\n",
+            path, (unsigned)mode, strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
 static void
 ftntoss_notify_all_processes(int sig)
 {
@@ -3184,6 +3332,7 @@ rewrite_conf_last_text(int confid, long *new_textnum)
     FILE *out;
     char tmpfile[PATH_MAX];
     LONG_LINE line;
+    struct stat conf_st; /* modified on 2026-07-09, PL */
     int found = 0;
 
     if (new_textnum == NULL)
@@ -3191,6 +3340,11 @@ rewrite_conf_last_text(int confid, long *new_textnum)
 
     if (snprintf(tmpfile, sizeof(tmpfile), "%s.ftntoss.tmp", CONF_FILE) >= (int)sizeof(tmpfile)) {
         fprintf(stderr, "[ERROR] CONF_FILE temp path too long\n");
+        return -1;
+    }
+
+    if (stat(CONF_FILE, &conf_st) == -1) {
+        perror(CONF_FILE);
         return -1;
     }
 
@@ -3204,6 +3358,13 @@ rewrite_conf_last_text(int confid, long *new_textnum)
     if (out == NULL) {
         perror(tmpfile);
         fclose(in);
+        return -1;
+    }
+
+    if (ftntoss_fix_fd_like_stat(out, tmpfile, &conf_st) != 0) {
+        fclose(in);
+        fclose(out);
+        unlink(tmpfile);
         return -1;
     }
 
@@ -3343,6 +3504,13 @@ send_ftn(int confid, const char *area, const struct fido_msg *msg, long com,
     fp = fopen(path, "w");
     if (fp == NULL) {
         perror(path);
+        free(mbuf);
+        return -1;
+    }
+
+    if (ftntoss_fix_fd_to_sklaff(fp, path, 0600) != 0) {
+        fclose(fp);
+        unlink(path);
         free(mbuf);
         return -1;
     }


### PR DESCRIPTION
Safer behaviour :

1. ftntoss detects problematic user permission situations before importing anything, and stops right there with an error message.

2. If convenient we can also run ftntoss as root / sudo, it's clever enough to set permissions on imported echomail (and the rewritten conf_file) just as Sklaffkom expects them :

`sklaff:sklaff 0600`

This will match the rest of the sklaff database perfectly.

I still recommend running both ftntoss, binkd and crashmail as the "sklaff"-user though, but I can also see value in having a separate "ftn"-user responsible for the ftn-operations and its files. In that case it's now safe to run ftntoss as root instead.