### PR TITLE
Peter/master

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -103,6 +103,22 @@ check_prompt_writable_file(const char *path)
 }
 
 static int
+check_prompt_optional_writable_file(const char *path)
+{
+    int fd;
+
+    fd = open(path, O_RDWR);
+    if (fd == -1) {
+        if (errno == ENOENT)
+            return 0;
+        return set_prompt_storage_error(path, "open rw");
+    }
+
+    close(fd);
+    return 0;
+}
+
+static int
 check_prompt_db_tree(const char *dir)
 {
     DIR *dp;
@@ -163,6 +179,9 @@ sklaff_storage_ok_for_prompt(void)
      * mainly read it.  Check O_RDWR here so the guard matches real use.
      */
     if (check_prompt_writable_file(CONF_FILE) == -1)
+        return 0;
+
+    if (check_prompt_optional_writable_file(ACTIVE_FILE) == -1)
         return 0;
 
     if (check_prompt_db_tree(SKLAFF_DB) == -1)

--- a/commands.c
+++ b/commands.c
@@ -2225,8 +2225,8 @@ cmd_only(char *args)
 
 /* New helper because we won't be sending sf7 in outgoing e-mail anymore (makes no sense 2026) PL 2026-05-26 */
 static void
-write_mail_utf8(FILE *pipe, const char *return_path, const char *subject_sf7,
-                const char *body_sf7)
+write_mail_utf8(FILE *pipe, const char *from_addr, const char *to_addr,
+                const char *subject_sf7, const char *body_sf7)
 {
     char *utf8_subject;
     char *utf8_body;
@@ -2240,7 +2240,8 @@ write_mail_utf8(FILE *pipe, const char *return_path, const char *subject_sf7,
         return;
     }
 
-    fprintf(pipe, "%s%s\n", MSG_EMRETURN, return_path);
+	fprintf(pipe, "%s%s\n", MSG_EMRETURN, from_addr);
+    fprintf(pipe, "To: %s\n", to_addr);
     fprintf(pipe, "MIME-Version: 1.0\n");
     fprintf(pipe, "Content-Type: text/plain; charset=UTF-8\n");
     fprintf(pipe, "Content-Transfer-Encoding: 8bit\n");
@@ -2345,7 +2346,7 @@ cmd_mail(char *args)
 			pw = getpwuid(Uid);
 			snprintf(tmpstr, sizeof(tmpstr), "<%s@%s>", pw->pw_name, MACHINE_NAME);
 
-			write_mail_utf8(pipe, tmpstr, th.subject, inbuf);
+			write_mail_utf8(pipe, tmpstr, mailrec, th.subject, inbuf);
 
 			pclose(pipe);
 
@@ -2356,7 +2357,7 @@ cmd_mail(char *args)
     		(void) save_mailcopy(mailrec, th.subject, inbuf);
 			}
 
-free(inbuf);       
+			free(inbuf);
             unlink(fname);
             output("%s\n\n", MSG_MAILED);
         }
@@ -2533,7 +2534,7 @@ cmd_personal(char *args)
        	pw = getpwuid(Uid);
 	   	snprintf(tmpstr, sizeof(tmpstr), "<%s@%s>", pw->pw_name, MACHINE_NAME);
 
-	   	write_mail_utf8(pipe, tmpstr, th.subject, inbuf);
+		write_mail_utf8(pipe, tmpstr, mailrec, th.subject, inbuf);
 
 	   	pclose(pipe);
 
@@ -3123,7 +3124,7 @@ cmd_comment(char *args)
        	pw = getpwuid(Uid);
 		snprintf(tmpstr, sizeof(tmpstr), "<%s@%s>", pw->pw_name, MACHINE_NAME);
 
-		write_mail_utf8(pipe, tmpstr, th.subject, inbuf);
+		write_mail_utf8(pipe, tmpstr, mailrec, th.subject, inbuf);
 
 		pclose(pipe);
 
@@ -4511,28 +4512,12 @@ cmd_off_flag(char *args)
 int
 cmd_info(char *args)
 {
-    int fd;
-    char *buf;
+    (void)args;
 
     output("\n");
-    if (file_exists(INFO_FILE)) {
-        output("%s\n", MSG_NOINFO);
-    } else {
-        if ((fd = open_file(INFO_FILE, 0)) == -1) {
-            sys_error("cmd_info", 1, "open_file");
-            return -1;
-        }
-        if ((buf = read_file(fd)) == NULL) {
-            sys_error("cmd_info", 2, "read_file");
-            return -1;
-        }
-        if (close_file(fd) == -1) {
-            sys_error("cmd_info", 3, "close_file");
-            return -1;
-        }
-        output(buf);
-    }
+    display_info();
     output("\n");
+
     return 0;
 }
 

--- a/etc/info.eng
+++ b/etc/info.eng
@@ -1,0 +1,248 @@
+General
+-------
+SklaffKOM was developed mainly from late 1992 through 1994 by a
+small group of cheerful enthusiasts. Since then it has continued to
+grow, more or less constantly, with new features and improvements. The
+program runs in most UNIX environments and is available in Swedish and
+English.
+
+SklaffKOM is released under the GNU license. This text gives you a
+tour of how the program works and what makes it a little different from
+other systems of the same kind.
+
+For more information about SklaffKOM, please visit
+https://www.sklaffkom.se.
+
+Conferences
+-----------
+There are four kinds of conferences in SklaffKOM: open, closed, secret
+and news conferences. Secret conferences are invisible everywhere in
+the system except to the conference creator and to users who have
+permission to enter them.
+
+Conferences are created with "Create conference". If the conference
+name contains words in parentheses, those words are not counted as part
+of the name. For example, you enter the conference "(SklaffKOM)
+suggestions" by typing "Goto suggestions".
+
+To see which conferences exist, use "List conferences". Conferences
+marked with an asterisk before the name are conferences you do not
+subscribe to. News conferences are normally created only by the
+administration user, on request from users.
+
+The conference creator can use "Add permissions" and
+"Subtract permission" for users in their conference. Having permission
+means that you may subscribe to the conference. All subscribers may read
+and write articles, and may also transfer files in the conference. To
+see who has permission in a conference, use "List permissions".
+
+You subscribe to a conference with "Subscribe". You can leave a
+conference with "Unsubscribe". To see who subscribes to a conference,
+use "List subscribers".
+
+The conference creator cannot delete articles in the conference. Only
+the author of an article can delete it. The name of a conference can be
+changed by its creator with "Change conferencename". The conference
+can also be deleted by its creator with "Delete conference".
+
+Articles
+--------
+Articles are arranged in trees, one separate set of trees for each
+conference. Each new article is the root of a tree, and its follow-ups
+are branches. Normally you read articles from the root and onward
+through the tree. Articles cannot be moved between conferences, and one
+article cannot belong to several conferences at the same time.
+
+SklaffKOM keeps track of three articles for you at all times: the last
+article you read, the "latest" article and the "followed-up" article.
+If you want to read the last article again, use "again".
+
+The "latest" article is the article most recently read with
+"next article" or "next follow-up". It can be referred to as "latest"
+in all commands that work with articles, such as "Read", "Follow-up"
+and "Display".
+
+The "followed-up" article is the article that the "latest" article is
+a follow-up to. It can be referred to in the same way as the "latest"
+article, for example with "Display followed-up". This can also be
+abbreviated as "-". If you have read too far, use "Back" to step back
+a chosen number of articles.
+
+Articles are written in conferences with "Post" or "Write". Follow-ups
+to articles or mail are written with "Follow-up". Personal replies,
+which end up in the original author's mailbox, are written with
+"Reply".
+
+Private mail to other users is written with "Mail" and the user's
+name. If you have the copy flag for sent mail turned on, you will also
+receive a copy of the message in your own mailbox. If the name contains
+an @ character, SklaffKOM assumes that you want to send email to
+someone on the Internet.
+
+Articles are normally read by pressing <RETURN>. If you want to read a
+specific article, use "Read" or "Display", or enter the article number
+as a command by itself. Articles are deleted with "Delete article",
+which can only be used by the author of the article.
+
+Editor
+------
+SklaffKOM uses a simple line editor. There is no way to do something
+like "!other" and continue writing a text later. If you are thrown out
+of the system because the modem connection drops, however, you may
+continue entering the interrupted text the next time you log in.
+
+The editor wraps lines automatically, and you can move back to the
+previous line, even back up to the subject line. Tell and Shout
+messages can be sent and received from inside the editor.
+
+The text you are editing can be read with "!read". "!whole" or Ctrl-L
+shows the whole text, including the header. "!change" lets you change a
+specific line in the text. Ctrl-X or Ctrl-U deletes the whole current
+line, and Ctrl-W deletes one word backwards.
+
+You can also delete and insert lines with "!delete" and "!insert".
+A text is saved with "!save"/"!enter", or with Ctrl-Z/Ctrl-D. The text
+you are following up can be displayed again with "!display". If you
+want to throw your text away, type "!abort" or press Ctrl-C. Help in
+the editor is available with "!help".
+
+Moving From The Editor
+----------------------
+The command "!move" is now available in the editor. It takes a
+conference name as its argument and moves the text you are writing
+there when it is saved. You can only move texts to conferences where
+you are a subscriber. The command only works while writing a follow-up
+in a conference, not for mail, new articles or personal replies.
+
+The article being followed up does not know that it has been followed
+up elsewhere. In other words, there is no note below the original
+article saying that a follow-up exists in another conference. There are
+two reasons for this:
+
+1. Technically, it is hard to make this work well.
+2. It keeps stray chatter from one conference out of another. In other
+   systems, commands like !move have often been used to add a silly
+   comment to a serious article and move it into a junk conference.
+
+When you read the moved follow-up, you can still display the article it
+follows up with "Display followed-up" or "-" as usual, even if you are
+not a subscriber to the conference where that article lives. You must,
+however, have permission to become a subscriber in order to see it. If
+a follow-up has been moved from a conference you are not allowed to
+enter, you will never be told that it is a follow-up at all.
+
+Skipping And Unreading
+----------------------
+SklaffKOM has a few commands for choosing which articles you want to
+keep unread. They fall into three groups: commands for skipping
+articles, commands for making articles unread, and the command "Only".
+
+If you want to mark all articles in the current branch as read, so that
+you do not have to read them, use "Skip branch". If you want to mark
+the whole tree as read, use "Skip tree".
+
+To mark one article as unread, use "Unread article". You will then get
+to read the article again the next time you log in to SklaffKOM. If you
+want to mark every article in the current tree as unread, use
+"Unread tree".
+
+If you want to mark part of a tree as unread, meaning one article and
+all of its follow-ups, their follow-ups, and so on, use
+"Unread branch" and say which article you want to start from. This is
+handy when you have used "Display followed-up" several times and then
+want to reread the discussion from the point where it started, without
+having to use "Only".
+
+"Only" is used to set the number of unread articles in a conference,
+working backwards in time. For example, "Only 10" marks the 10 most
+recently written articles in the conference as unread.
+
+Search Functions
+----------------
+SklaffKOM has two commands for searching for strings in articles:
+"Find" and "Globalfind". They work the same way, except that
+"Globalfind" searches all conferences in the system while "Find" only
+searches the conference you are currently in. Both commands take a text
+string as their argument and then show every article number where the
+string occurs, together with the full line that contains it.
+
+If you want to list the subject lines in the current conference, use
+"List subjects". The newest article is shown first. If you give a text
+string as an argument, only subject lines containing that string are
+shown.
+
+Tell And Shout
+--------------
+To talk directly to other logged-in users without writing articles in
+the system, there are two commands: "Tell" and "Shout"/"Yell". They
+work the same way, except that "Shout"/"Yell" sends the message to
+everyone who is logged in, while "Tell" sends it only to one specific
+person.
+
+The syntax for "Tell" is "Tell <user>, <message>". If you only type
+"Tell <user>", SklaffKOM will ask for message lines to send to that
+person until you enter an empty message. "Shout"/"Yell" takes no user
+name, but otherwise works the same way.
+
+You never have to do anything special to receive a message. It appears
+automatically when the system is waiting for input. The same thing
+happens when a new article is written in one of your conferences: your
+prompt is redrawn automatically.
+
+User Profile
+------------
+There are several things you can set for your user. They are described
+below:
+
+Flags: These can be either off or on. Use "List flags" to see which
+flags exist and what their current status is. To change a flag, type
+either "Turn off <flag>" or "Turn on <flag>".
+
+Note: A text that is shown every time someone writes mail or a personal
+reply to you. It is changed with "Change note".
+
+Password: You should change this the first time you log in. Use
+"Change password".
+
+Personal information: Details such as address, phone number and the
+like can be changed with "Change personal information". These details
+are later visible if someone uses "Status" on your user.
+
+Timeout: The time before you are logged out if you do not press any
+key. It is normally 0 minutes, which means never. Change it with
+"Change timeout". One minute before you are logged out, you will get a
+warning.
+
+Login script: A text containing all commands you want SklaffKOM to run
+each time you log in, for example "Who" and "List news". Use
+"Change loginscript" and enter the commands in the editor, one command
+per line, then save as usual.
+
+Information
+-----------
+SklaffKOM has several commands for getting information. "List users"
+shows all users, sorted by last name. "Last" shows when each user last
+logged in. "List news" shows where you have unread articles.
+"List commands"/"?" shows which commands are available, and "Help"
+gives help for a specific command.
+
+"Who" shows who is using SklaffKOM right now. "Where" shows which
+conference you are currently in. "Time" shows the system clock.
+
+"Status" shows detailed information about a user or a conference, and
+"Information" gives general information about the system.
+
+File Handling
+-------------
+The SklaffKOM file system is built so that every conference
+automatically has its own file area. Everyone who subscribes to the
+conference may do everything with the files in that conference: upload
+files with "Upload", download files with "Download", list files with
+"List files", describe files with "Describe", and delete files with
+"Delete file".
+
+Leaving
+-------
+You leave SklaffKOM with "Logout", and restart it with "Restart".
+
+>>> This text was auto translated using ChatGPT. Apologies. <<<

--- a/etc/info.swe
+++ b/etc/info.swe
@@ -1,0 +1,237 @@
+Allmänt
+-------
+SklaffKOM utvecklades primärt under slutet av 1992 fram till 1994 
+av några glada entusiaster och har sedan dess utvecklats mer 
+eller mindre konstant med nyheter. Programmet kan köras under 
+de flesta UNIX-miljöer och finns på svenska och engelska.  
+
+SklaffKOM lyder under GNU-licens.  I den här texten presenteras 
+hur programmet fungerar samt vad som skiljer det från andra 
+liknande system.
+
+För mer information om Sklaffkom, vänligen besök https://www.sklaffkom.se.
+
+Möten
+-----
+Det finns fyra typer av möten som kan skapas i SklaffKOM: öppna,
+slutna, hemliga och news.  Hemliga möten är osynliga överallt i
+systemet utom för mötesskaparen och de som har rättigheter i mötet.
+Möten skapas med kommandot "skapa möte".  Om mötesnamnet innehåller
+ord inom parentes räknas inte dessa ord in i mötets namn.  T.ex. går
+man till mötet "(SklaffKOM) synpunkter" genom att skriva "gå
+synpunkter".  För att se vilka möten som finns ges kommandot "lista
+möten".  Möten med en asterisk innan mötesnamnet är möten du inte är
+medlem i.  News-möten skapas normalt bara av
+administrations-användaren på användarnas beställning.
+
+Mötesskaparen kan addera och subtrahera rättigheter för användare i
+sitt möte.  Att ha rättigheter innebär att man får bli medlem i mötet.
+Alla som är medlemmar har rätt att läsa och skriva texter, samt
+överföra filer till mötet.  För att se vilka som har rättigheter i ett
+möte ges kommandot "lista rättigheter".
+
+Medlemskap i möte fås genom kommandot "medlem".  Man kan utträda ur
+ett möte med kommandot "utträd".  För att se vilka som är medlemmar i
+ett möte skriver man "lista medlemmar".
+
+Mötesskaparen kan inte radera texter i mötet, utan bara författaren
+till en text kan radera den.  Mötets namn kan ändras av mötesskaparen
+med kommandot "ändra mötesnamn".  Mötet kan även raderas av sin
+skapare med kommandot "radera möte".
+
+Texter
+------
+Texterna organiseras i träd som är separata för varje möte.  Varje
+inlägg motsvarar roten på trädet och dess kommentarer är förgreningar.
+Normalt läser man texter från roten och uppåt i trädet.  Texter kan
+inte flyttas mellan möten och en text kan inte ligga i flera möten
+samtidigt.
+
+SklaffKOM håller reda på tre stycken texter åt dig hela tiden, den
+sist lästa texten, den "senaste" texten och den "kommenterade" texten.
+Om du vill läsa den sist lästa texten igen ger du kommandot "igen".
+Den "senaste" lästa texten är den text som senast lästes med kommandot
+"(Läsa) nästa text" eller "(Läsa) nästa kommentar".  Denna text kan
+refereras till med "senaste" i alla kommandon som arbetar med texter,
+t.ex. "läsa", "kommentera" och "återse".  Den "kommenterade" texten är
+den text som den "senaste" lästa texten är en kommentar till och kan
+refereras på samma sätt som den "senaste" texten, t.ex. "återse
+kommenterade" (kan även förkortas till "-").  Har du läst för långt
+kan du använda kommandot "backa" för att backa tillbaka ett visst
+antal texter.
+
+Texter skrivs i möten med kommandot "inlägg" eller "skriv".
+Kommentarer till texter eller brev görs med "kommentera".  Personliga
+kommentarer (kommentarer som hamnar i den kommenterade författarens
+brevlåda) görs med "personlig".
+
+Privata brev till andra användare skrivs med kommandot "brev" och
+användares namn.  Om du har flaggan "kopia (av sända brev)" påslagen
+får du även en kopia av brevet i din egen brevlåda.  Om namnet
+innehåller ett @ antas det att du vill skicka ett email till någon
+annan i Internet-världen.
+
+Texter läsas normalt genom att trycka <RETURN>.  Vill man läsa en
+speciell text kan kommandona "läsa" eller "återse" användas, eller
+textnumret anges ensamt som kommando.  Texter raderas med kommandot
+"radera text" som bara kan utföras av textförfattaren.
+
+Editor
+------
+SklaffKOM använder en enkel radeditor.  Det finns inte möjlighet att
+göra t.ex. "!annat" och fortsätta en text senare.  Blir man utslängd
+ur systemet pga avbrott i modemförbindelsen får man dock fortsätta
+skriva in sin avbrutna text nästa gång man loggar in.
+
+Editorn gör automatiska radbrytningar och det finns möjlighet att
+"backa" upp på föregående rad (även upp till ärenderaden).  "Sägar"
+och "skrik" kan skickas och tas emot innefrån editorn.  Texten man
+editerar kan läsas "!läsa".  "!hela" eller Ctrl-L visar hela texten
+inklusive texthuvud.  "!ändra" tillåter att man ändrar en speciell rad
+i texten.  Ctrl-X eller Ctrl-U raderar hela den rad man står på och
+Ctrl-W raderar ett ord bakåt.  Du kan även radera och infoga rader med
+kommandona "!radera" resp "!infoga". En text sparas med "!spara"/
+"!lägga" eller med Ctrl-Z/Ctrl-D.  Den text man kommenterar kan
+återses med "!återse".  Vill man kasta bort sin text skriver man
+"!bort" eller trycker Ctrl-C.  Hjälp i editorn fås med "!hjälp".
+
+Flytta i editorn
+----------------
+Kommandot "!flytta" finns numera i editorn. Det tar ett mötesnamn som
+argument och flyttar texten man skriver dit när den sparas. Det går bara
+att flytta texter till möten man är medlem i. Kommandot fungerar bara vid
+"kommentera" i möten, inte vid brev, inlägg eller personliga kommentarer.
+
+Texten som kommenteras vet inte om att den är kommenterad, det vill säga
+att det står inget om att det finns en kommentar i ett annat möte under
+själva texten. Detta av två orsaker:
+
+1. Rent tekniskt är det svårt att få det att fungera.
+2. Man slipper en massa struntprat från ett möte i ett annat. !flytta
+   har ju ofta används i andra system för att skriva någon fånig
+   kommentar till en seriös text och addera den till ett slaskmöte.
+
+När man läser den flyttade kommentaren går det att återse den kommenterade
+texten med "å k" eller "-" som vanligt, även om man inte är medlem i det
+mötet där texten finns. Dock måste man ha behörighet att BLI medlem för
+att få se texten. [r en kommentar flyttad från ett möte man inte har
+behörighet att titta i får man aldrig veta att det är en kommentar över
+huvud taget.
+
+Hoppa över och oläs
+-------------------
+SklaffKOM innehåller några kommandon för att välja ut vilka texter man
+vill ha som olästa.  Dessa är indelade i tre grupper, kommandon för
+att "hoppa över" texter, kommandon för att "oläsa" texter samt
+kommandot "endast".
+
+Vill man läsmarkera (alltså slippa läsa) alla texter i den gren av
+text-trädet som man befinner sig i används kommandot "hoppa över".
+Vill man läsmarkera hela trädet används kommandot "hoppa träd".
+
+För att markera en text som oläst används kommandot "oläs text".  Då
+kommer du att få läsa om texten nästa gång du loggar in i SklaffKOM.
+Vill du oläsmarkera alla texter i trädet du står i ges kommandot "oläs
+träd".  
+
+Vill du oläsmarkera en del av trädet, det vill säga en viss text och
+alla dess kommentar och underkommentarer osv. används du kommandot
+"oläs delträd" och anger från vilken text du vill ha oläst.  Praktiskt
+när man gör "återse kommenterade" flera gånger och sen vill läsa om
+från det ställe där diskussion startade utan att behöva använda
+"endast".
+
+"Endast" används för att sätta antalet olästa texter i ett möte och
+arbetar kronologiskt bakåt.  "endast 10" oläsmarkerar t.ex. de 10
+senast skrivna texterna i mötet.
+
+Sökfunktioner
+-------------
+SklaffKOM har två funktioner för att söka efter strängar i texter:
+"sök" och "globalsök".  Dessa fungerar på samma sätt förutom att
+"globalsök" söker i alla möten i systemet och "sök" bara söker i det
+möte du befinner dig i.  Båda kommandona tar en textsträng som
+argument och visar sedan alla textnummer där textsträngen förekommer
+samt hela den rad som innehåller strängen.
+
+Vill du lista ärenderaderna i det möte du befinner dig i kan du skriva
+"lista ärenden" och få se dessa med den senast skrivna texten först.
+Anger du en textsträng som argument visas bara de ärenderader som
+innehåller textsträngen.
+
+Säg och skrik
+-------------
+För att meddela sig med andra användare direkt och inte behöva skriva
+texter i systemet finns det två kommandon: "säg" och "skrik"/"ropa".
+Dessa fungerar på samma sätt förutom att "skrik"/"ropa" skickar
+meddelandet till samtliga inloggade och "säg" endast skickar till en
+specifik person.
+
+Syntaxen för "säg" är "säg <användare>, <meddelande>".  Om bara "säg
+<användare>" ges kommer SklaffKOM att fråga efter rader med
+meddelanden att skicka till personen tills ett tomt meddelande ges.
+Kommandot "skrik"/"ropa" tar inget användarnamn men fungerar i övrigt
+på samma sätt.
+
+Du behöver aldrig göra något för att ta emot ett meddelande, det
+kommer automatiskt upp när systemet väntar på inmatning.  Samma sak
+gäller om det skrivs en ny text i något möte, din prompt skrivs om
+automatiskt.
+
+Användarprofil
+--------------
+Det finns ett flertal saker du kan ställa in för din användare.  Dessa
+beskrivs nedan:
+
+Flaggor:  Dessa kan antingen vara "av" eller "på".  Ger du kommandot
+"lista flaggor" ser du vilka flaggor som finns och deras status.  För
+att ändra en flagga skriver du antingen "slå av <flagga>" eller "slå
+på <flagga>".
+
+Lapp:  En text som kommer upp varje gång någon skriver ett brev eller
+en personlig kommentar till dig, ändras med kommandot "ändra lapp".
+
+Lösenord:  Detta bör ändras första gången du loggar in och görs med
+kommandot "ändra lösenord".
+
+Personuppgifter:  Uppgifter som adress, telefonnummer och dylikt kan
+du ändra med "ändra personuppgifter".  Dessa syns senare om man gör
+"status" på din användare.
+
+Timeout: Den tid det tar innan du blir utloggad om du inte rör vid
+någon tangent.  Den är normalt 0 minuter, det vill säga aldrig.  Du
+ändrar den med kommandot "ändra timeout".  En minut innan du blir
+utloggad får du en varning.
+
+Uppstartskommandon: En text som innehåller alla de kommandon som du
+vill ska utföras varje gång du loggar in, t.ex. "vilka" och "lista
+nyheter".  Använd kommandot "ändra uppstartskommandon" och skriv in
+kommandona i editorn, ett kommando på varje rad och spara som vanligt.
+
+Information
+-----------
+I SklaffKOM finns det ett flertal kommandon för att få information.
+"lista användare" ger dig en lista på alla användare sorterad på
+efternamnet.  "lista senaste" visar när varje användare senast
+loggade in.  "lista nyheter"/"lista olästa" visar var du har olästa
+texter.  "lista kommandon"/"?" visar vilka kommandon som finns och
+"hjälp" ger hjälp för ett speciellt kommando.
+
+"vilka" visar vilka som använder SklaffKOM just nu.  "var" visar i
+vilket möte du befinner dig.  "tiden" visar vad systemets klocka är.
+
+"status" visar detaljerad information om en användare eller ett möte
+och "information" ger allmän information om systemet.
+
+Filhantering
+------------
+SklaffKOM filsystem är uppbyggt så att varje möte automatiskt har en
+area för filer.  Alla som är medlemmar i mötet har rätt att göra allt
+med filerna i mötet, det vill säga: "ladda upp" filer till mötet,
+"ladda ner" filer från mötet, "lista filer" i mötet, "beskriva filer"
+i mötet samt "radera filer" i mötet.
+
+Avsluta
+-------
+SklaffKOM avslutas genom något av kommandona "sluta" eller "logout" och
+omstartas med "börja om".

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -202,6 +202,7 @@ static void ftntoss_notify_all_processes(int sig); /* modified on 2026-07-05, PL
 static int ftntoss_get_sklaff_ids(uid_t *uid, gid_t *gid); /* modified on 2026-07-09, PL */
 static int ftntoss_fix_fd_to_sklaff(FILE *fp, const char *path, mode_t mode); /* modified on 2026-07-09, PL */
 static int ftntoss_fix_fd_like_stat(FILE *fp, const char *path, const struct stat *st); /* modified on 2026-07-09, PL */
+static int ftntoss_fix_control_file(const char *path, mode_t mode); /* modified on 2026-07-09, PL */
 
 static void
 sklaff_version_no_build(char *out, size_t outsz)
@@ -2046,6 +2047,68 @@ ftntoss_fix_fd_like_stat(FILE *fp, const char *path, const struct stat *st)
     return 0;
 }
 
+static int
+ftntoss_fix_control_file(const char *path, mode_t mode)
+{
+    struct stat st;
+    uid_t uid;
+    gid_t gid;
+
+    if (path == NULL)
+        return -1;
+
+    if (stat(path, &st) == -1) {
+        if (errno == ENOENT)
+            return 0;
+        fprintf(stderr,
+            "[ERROR] ftntoss: stat(%s) failed: %s\n",
+            path, strerror(errno));
+        return -1;
+    }
+
+    if (!S_ISREG(st.st_mode))
+        return 0;
+
+    if (ftntoss_get_sklaff_ids(&uid, &gid) != 0)
+        return -1;
+
+    /*
+     * ACTIVE_FILE is normally a SklaffKOM control file owned by sklaff,
+     * often with group root and mode 0600.  ftntoss only reads it, but after
+     * an import it wakes already active SklaffKOM sessions.  Those sessions
+     * may then open ACTIVE_FILE while rebuilding their prompt, so repair the
+     * same ownership class here before signalling them.
+     *
+     * Preserve the existing group when running as root, just like the
+     * CONF_FILE rewrite helper does.
+     *
+     * modified on 2026-07-09, PL
+     */
+    if (geteuid() == 0) {
+        if (chown(path, uid, st.st_gid) == -1) {
+            fprintf(stderr,
+                "[ERROR] ftntoss: chown(%s, sklaff:%ld) failed: %s\n",
+                path, (long)st.st_gid, strerror(errno));
+            return -1;
+        }
+    } else if (geteuid() != uid) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: cannot safely fix %s as uid %ld; "
+            "expected root or sklaff\n",
+            path, (long)geteuid());
+        return -1;
+    }
+
+    if (chmod(path, mode) == -1) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: chmod(%s, %04o) failed: %s\n",
+            path, (unsigned)mode, strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
 static void
 ftntoss_notify_all_processes(int sig)
 {
@@ -2066,6 +2129,9 @@ ftntoss_notify_all_processes(int sig)
      *
      * modified on 2026-07-05, PL
      */
+    if (ftntoss_fix_control_file(ACTIVE_FILE, 0600) != 0)
+        return;
+
     fp = fopen(ACTIVE_FILE, "r");
     if (fp == NULL)
         return;

--- a/lang.h
+++ b/lang.h
@@ -114,7 +114,7 @@
 #define MSG_BBSLINK01 "BBSLink {r en slags 'door server' dit ett hundratal BBS'er {r anslutna."
 #define MSG_BBSLINK02 "Varje spel har en unik 'spelkod' som man anger f|r att spela."
 #define MSG_BBSLINK03 "Exempel : 'spela usrp' starar spelet Usurper."
-#define MSG_BBSLINK_OFF "Sysop har inte konfigurerat BBSLink på detta system"
+#define MSG_BBSLINK_OFF "Sysop har inte konfigurerat BBSLink p{ detta system"
 
 /* commands.c */
 
@@ -307,16 +307,16 @@
 #define MSG_NO_ZORK	"No z3-file found, sorry"  					/*Zork */
 #define MSG_BADARG      "\nF|ljande infocom-spel finns f|r n{rvarande :\n\nZork 1\nZork 2\nZork 3\n\nF|r att spela, ge kommandot Zork <nr>.\n\n"	/* Zork */
 #define MSG_SUCCESSUL   "Tackar f|r det! \nBeskriv nu g{rna filen genom att ge kommandot 'Beskriv <filnamn>'."
-#define MSG_NETHACKER01	"Fel: Kan inte starta Nethack - har SysOp glömt att installera den?"
+#define MSG_NETHACKER01	"Fel: Kan inte starta Nethack - har SysOp gl|mt att installera den?"
 #define MSG_FILE_DB_ER	"Strul med filkatalogen. Meddela SysOp."
 #define MSG_ULPRGMERROR "Uploadprogrammet saknas eller kan inte k|ras. Kontakta SysOp."
-#define MSG_FILES_OFF 	"Fil|verf|ringar är inte konfigurerade på detta system."
+#define MSG_FILES_OFF 	"Fil|verf|ringar }r inte konfigurerade p{ detta system."
 #define MSG_OPEN_C_E	"Fel : kunde inte |ppna confxtra. Meddela SysOp!"
 #define MSG_READ_C_E	"Fel : kunde inte l{sa confxtra. Meddela SysOp!"
 #define MSG_WRITE_C_E	"Fel : kunde inte skriva till confxtra. Meddela SysOp!"
 #define MSG_BLOCKINTRO1	"Redigera blockerade avs{ndare, en per rad."
-#define MSG_BLOCKINTRO2	"Tomma rader och rader som börjar med # ignoreras."
-#define MSG_BLOCKED_MSG	"(Text %ld dold: blockerad avsändare)"
+#define MSG_BLOCKINTRO2	"Tomma rader och rader som b|rjar med # ignoreras."
+#define MSG_BLOCKED_MSG	"(Text %ld dold: blockerad avs}ndare)"
 
 /* Nytt (Se) tiden-kommando */
 #define MSG_DISPTIME    "Klockan {r nu"
@@ -328,7 +328,7 @@
 /* Fotnot */
 #define MSG_FOOTNOTE	"Fotnot"
 #define MSG_USEFOOT     "Syntax: fotnot <textnummer>"
-#define MSG_FOOTINLOCAL "Du kan bara l{gga in fotnötter i lokala möten."
+#define MSG_FOOTINLOCAL "Du kan bara l{gga in fotn|tter i lokala m|ten."
 #define MSG_NOREADFILE  "Kunde inte l}sa textfilen. Kontakta SysOp"
 #define MSG_NOPARSEFILE "Kunde inte tolka textfilen. Kontakta SysOp."
 #define MSG_FNERROR01   "Du kan bara anv}nda detta kommando p} dina egna texter."
@@ -354,7 +354,7 @@
 /* Mötesbeskrivningar */
 #define MSG_CURRDESC    "Nuvarande beskrivning:"
 #define MSG_NODESCYET   "(Ingen beskrivning finns {nnu)"
-#define MSG_GIVENEWDESC "Ange ny beskrivning (max 80 tecken), eller l{mna tomt för att ta bort:"
+#define MSG_GIVENEWDESC "Ange ny beskrivning (max 80 tecken), eller l{mna tomt f|r att ta bort:"
 #define MSG_DESCDEL     "Beskrivningen togs bort."
 #define MSG_DESCERROR01 "Ingen beskrivning att ta bort, eller fel vid radering."
 #define MSG_DESCCONFIRM "Beskrivningen {r nu uppdaterad."
@@ -1428,7 +1428,7 @@
 #define MSG_INSMODEM	"\nModem    : "
 #define MSG_INSTELE	"\nTelephone: "
 #define MSG_INSPOST     "\nE-mail : "
-#define MSG_APPLIED	"We have now received your application and will get back to you shortly!\nWelcome!\n\n"
+#define MSG_APPLIED	"We have now received your application and will get back to you shortly!\nWelcome back soon!\n\n"
 #define MSG_UIDINUSE	"login-name in use by another user."
 
 /* mailtoss.c */

--- a/lib/display_langfile.c
+++ b/lib/display_langfile.c
@@ -89,3 +89,7 @@ void display_logout(void)
     display_langfile(LOGOUT_FILE, LOGOUT_FILE_ENG, LOGOUT_FILE_SWE);
 }
 
+void display_info(void)
+{
+	display_langfile(INFO_FILE, INFO_FILE_ENG, INFO_FILE_SWE);
+}

--- a/sklaff.h
+++ b/sklaff.h
@@ -144,6 +144,8 @@ https://github.com/joakimmelin/sklaffkom/wiki/Install-Instructions */
 #define LOGOUT_FILE_ENG     "/usr/local/sklaff/etc/logout.eng"
 #define LOGOUT_FILE_SWE "/usr/local/sklaff/etc/logout.swe"
 #define INFO_FILE	SKLAFFDIR "/etc/info"
+#define INFO_FILE_ENG	SKLAFFDIR "/etc/info.eng"
+#define INFO_FILE_SWE	SKLAFFDIR "/etc/info.swe"
 #define LICENS_FILE	SKLAFFDIR "/etc/COPYING"
 #define DOWN_FILE 	SKLAFFDIR "/etc/down"
 #define PAY_FILE	SKLAFFDIR "/etc/pay"
@@ -404,6 +406,7 @@ void human_size(off_t bytes, char *out, size_t outsz);									/* For 1024-based
 void display_langfile(const char *base, const char *base_eng, const char *base_swe);        /* Support for multilingual display of files (news etc) 2025-09-24 PL */
 void display_news(void);
 void display_logout(void);
+void display_info(void);
 
 /* lib/ftn.c */
 void export_ftn_post_if_needed(struct CONF_ENTRY *ce, long textnum); /* modified on 2026-06-14, PL */


### PR DESCRIPTION
Fixes a bug in ftntoss that made the active-file confused. Importing while being logged in should no longer send error messages to the logged in user.

For good measure, the startup permissions / ownership checks in admin.c now also checks the active-file.

I hope ftntoss imports are problematic free from now on regardless how it's run :).

Coming up soon - netmail support 😍