### PR TITLE
Features : charset selection at login + new flag (always start in mailbox during login), as well as minor corrections and tweaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,9 @@ v1.33-rc1 Sunday 02 August 2026 PL
 * A new IBOL-parser (InterBBS OneLiner) seems functional but work remains on
   integrating it in SklaffKOM. At least we now have a way to fetch the data.
 
+* Character set "handshake" during login for users who did not yet pick a
+  charset flag. Only displayed once. Meant for new users.
+
 v1.33-rc1 Saturday 06 June 2026 JM
 
 * Changed language for swedish names of days to avoid intercaps and to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,32 @@
+v1.33-rc1 Sunday 02 August 2026 PL
+
+* Numerous small fixes. Code cleanup. Praise / Unpraise blocked in ftn, as
+  well as footnotes. No reason to dump those extra chars out to ftn :D.
+  Some ANSI colors changed for clarity. Some help files for commands
+  I have added are written finally (boooring). Rookie-mode (flag) provides
+  (some) help for beginners. Trying to make the startup screen more effective
+  UX-wise and I decided a flag (alternate startup screen) was the way to go.
+  Try it. Source file headers added, where these were missing (preparing for
+  upcoming sharp release ;)). Avoiding red color in conferences name etc, as
+  red suggest warning we'll save it for something useful. Some corrections
+  in the English language defines affecting startup screen fixed. Buggy
+  collission checks in cmd_create_conf and cmd_change_cname fixed, as well
+  as in cmd_delete_conf and cmd_unsubsribe. Yikes!
+
+* Mailtoss now can interpet HTML through the external cli browser Lynx.
+
+* ftntoss and related components seem to work as intended.
+
+* Started working on UX-improvements here and there, especially for new users.
+  The feature freeze I promised months ago seem to not have happened yet.
+
+* A new IBOL-parser (InterBBS OneLiner) seems functional but work remains on
+  integrating it in SklaffKOM. At least we now have a way to fetch the data.
+
 v1.33-rc1 Saturday 06 June 2026 JM
 
 * Changed language for swedish names of days to avoid intercaps and to
-  comply with swedish language standards. 
+  comply with swedish language standards.
 
 v1.33-rc1 Thursday 02 June 2026 PL
 

--- a/admin.c
+++ b/admin.c
@@ -513,6 +513,14 @@ display_welcome(void)
 
     set_flags(rc->flags);
 
+	/*
+     * If no character set has ever been selected, let SklaffKOM and
+     * the terminal agree on one before displaying any localized text.
+    */
+#if ENABLE_CHARSET_HANDSHAKE
+    if (!Utf8 && !Ibm && !Iso8859 && !Mac && !Force_sf7)
+        (void) select_charset();
+#endif
     if (Rookie_mode && !Alternate_intro) {
     display_intro();
     wait_for_intro_continue();

--- a/commands.c
+++ b/commands.c
@@ -4934,7 +4934,7 @@ cmd_list_flags(char *args)
     output_flag_line(Ansi_output, MSG_FLAG18F);
     output_flag_line(Alternate_intro, MSG_FLAG20F);
     output_flag_line(Rookie_mode, MSG_FLAG21F);
-
+    output_flag_line(Start_mailbox, MSG_FLAG22F);
     output("\n");
     return 0;
 }

--- a/conf.c
+++ b/conf.c
@@ -518,7 +518,21 @@ int
 set_first_conf(void)
 {
     int conf;
+    
+    /*
+    * Optional NiKom-style login:
+    * always stop in the Mailbox, even when it contains no unread mail.
+    */
+    if (Start_mailbox) {
+        set_conf(0);
+        return 0;
+    }
 
+    /*
+     * Original SklaffKOM behaviour:
+     * start in the Mailbox if it contains unread mail, otherwise
+     * continue to the first conference containing unread articles.
+     */    
     conf = 0;
     set_conf(conf);
     if (!more_text()) {

--- a/etc/help.eng/mail
+++ b/etc/help.eng/mail
@@ -7,3 +7,6 @@ Description:
 
   If you enter a email-adress (eg 'calle@skom.se') instead of a
   username, a email is sent instead.
+  
+  If you enter a netmail-adress (such as totte@21:3/24), a netmail
+  is sent instead.

--- a/etc/help.swe/mail
+++ b/etc/help.swe/mail
@@ -8,3 +8,6 @@ Beskrivning:
 
   Om en email-adress anges, allts} ett namn som inneh}ller '@',
   (ex calle@skom.se), skickas ist{llet ett email till personen i fr}ga.
+  
+  Om en netmail-adress anges (s}som totte@21:3/242) skickas ist{llet
+  ett netmail till personen i fr}ga.

--- a/etc/intro
+++ b/etc/intro
@@ -1,10 +1,10 @@
-Välkommen till SklaffKOM!
+V{lkommen till SklaffKOM!
 
-Här skriver du kommandon i stället för att välja i menyer.
-Tryck ENTER för att använda det föreslagna kommandot som 
-visas längst ned på skärmen. 
+H{r skriver du kommandon i st{llet f|r att v{lja i menyer.
+Tryck ENTER f|r att anv{nda det f|reslagna kommandot som 
+visas l{ngst ned på sk{rmen. 
 
-Skriv hjälp när du vill se vad du kan göra.
+Skriv hj{lp n{r du vill se vad du kan g|ra.
 
-När du känner dig hemma kan du stänga av nybörjarläget med:
-slå av nybörjarläge
+N{r du k{nner dig hemma kan du st{nga av nyb|rjarl{get med:
+sl} av nyb|rjarl{ge

--- a/etc/intro
+++ b/etc/intro
@@ -8,3 +8,4 @@ Skriv hj{lp n{r du vill se vad du kan g|ra.
 
 N{r du k{nner dig hemma kan du st{nga av nyb|rjarl{get med:
 sl} av nyb|rjarl{ge
+

--- a/etc/intro.swe
+++ b/etc/intro.swe
@@ -1,11 +1,10 @@
-Välkommen till SklaffKOM!
+V{lkommen till SklaffKOM!
 
-Här skriver du kommandon i stället för att välja i menyer.
-Tryck ENTER för att använda det föreslagna kommandot som 
-visas längst ned på skärmen. 
+H{r skriver du kommandon i st{llet f|r att v{lja i menyer.
+Tryck ENTER f|r att anv{nda det f|reslagna kommandot som 
+visas l{ngst ned på sk{rmen. 
 
-Skriv hjälp när du vill se vad du kan göra.
+Skriv hj{lp n{r du vill se vad du kan g|ra.
 
-När du känner dig hemma kan du stänga av nybörjarläget med:
-slå av nybörjarläge
-
+N{r du k{nner dig hemma kan du st{nga av nyb|rjarl{get med:
+sl} av nyb|rjarl{ge

--- a/etc/intro.swe
+++ b/etc/intro.swe
@@ -8,3 +8,4 @@ Skriv hj{lp n{r du vill se vad du kan g|ra.
 
 N{r du k{nner dig hemma kan du st{nga av nyb|rjarl{get med:
 sl} av nyb|rjarl{ge
+

--- a/etc/logout.swe
+++ b/etc/logout.swe
@@ -1,7 +1,7 @@
  /\_/\
 ( o.o )	<-	Mjau då!
  > ^ <
-			Besök även dessa utmärkta BBS'er :
+			Bes|k {ven dessa utm{rkta BBS'er :
 			---------------------------------
 			Delta City    : https://www.deltacity.se
 			Sklaffkom     : https://www.sklaffkom.se

--- a/ext_globals.h
+++ b/ext_globals.h
@@ -99,9 +99,10 @@ extern int Header;              /* email header		   */
 extern int Presbeep;            /* Beep at present msg     */
 extern int Ansi_output;         /* Allows ANSI colors      */
 extern int Utf8;                /* UTF-8 mode		   */
-extern int Force_sf7;                  /* SF7 selection during login (hidden flag) */  
+extern int Force_sf7;           /* SF7 selection during login (hidden flag) */
 extern int Alternate_intro;		/* Re-arranged intro screen */
 extern int Rookie_mode;			/* Extra help for new users */
+extern int Start_mailbox;       /* Always start in Mailbox during login */
 
 extern struct termios Tty_mode;
 extern sigset_t Oldmask;

--- a/ext_globals.h
+++ b/ext_globals.h
@@ -99,6 +99,7 @@ extern int Header;              /* email header		   */
 extern int Presbeep;            /* Beep at present msg     */
 extern int Ansi_output;         /* Allows ANSI colors      */
 extern int Utf8;                /* UTF-8 mode		   */
+extern int Force_sf7;                  /* SF7 selection during login (hidden flag) */  
 extern int Alternate_intro;		/* Re-arranged intro screen */
 extern int Rookie_mode;			/* Extra help for new users */
 

--- a/flag.c
+++ b/flag.c
@@ -157,7 +157,7 @@ set_flags(char *flags)
             i++;
             Header = atoi(i);
         } else
-            Header = 1;
+            Header = 0; /* default off */
 
         p = strstr(flags, "presbeep");
         if (p) {
@@ -229,7 +229,7 @@ set_flags(char *flags)
         Date = 0;
         Beep = 1;
         Clear = 0;
-        Header = 1;
+        Header = 0;
         Special = 0;
         Presbeep = 0;
         Old_who = 0;

--- a/flag.c
+++ b/flag.c
@@ -198,7 +198,13 @@ set_flags(char *flags)
             Utf8 = atoi(i);
         } else
             Utf8 = 0;  /* default off */
-
+        p = strstr(flags, "force_sf7");
+        if (p) {
+            i = strchr(p, '=');
+            i++;
+            Force_sf7 = atoi(i);
+         } else
+            Force_sf7 = 0;
         p = strstr(flags, "alternate_intro");
         if (p) {
             i = strchr(p, '=');
@@ -235,9 +241,92 @@ set_flags(char *flags)
         Old_who = 0;
         Ansi_output = 0;
         Utf8 = 0;
+        Force_sf7 = 0;
         Alternate_intro = 0;
         Rookie_mode = 1;
     }
+}
+
+/*
+ * save_flags - save the current global flag values to the user's sklaffrc
+ * ret: success (0) or failure (-1)
+ */
+
+int
+save_flags(void)
+{
+    struct SKLAFFRC *rc;
+    int n;
+    int ret;
+
+    rc = read_sklaffrc(Uid);
+    if (rc == NULL)
+        return -1;
+
+    n = snprintf(rc->flags, sizeof(rc->flags),
+        "say = %d\n"
+        "shout = %d\n"
+        "present = %d\n"
+        "ibm = %d\n"
+        "iso8859 = %d\n"
+        "mac = %d\n"
+        "subject_change = %d\n"
+        "end_default = %d\n"
+        "space = %d\n"
+        "copy = %d\n"
+        "author = %d\n"
+        "date = %d\n"
+        "beep = %d\n"
+        "clear = %d\n"
+        "header = %d\n"
+        "strip = %d\n"
+        "presbeep = %d\n"
+        "oldwho = %d\n"
+        "ansi = %d\n"
+        "utf8 = %d\n"
+        "force_sf7 = %d\n"
+        "alternate_intro = %d\n"
+        "rookie_mode = %d\n",
+        Say,
+        Shout,
+        Present,
+        Ibm,
+        Iso8859,
+        Mac,
+        Subject_change,
+        End_default,
+        Space,
+        Copy,
+        Author,
+        Date,
+        Beep,
+        Clear,
+        Header,
+        Special,
+        Presbeep,
+        Old_who,
+        Ansi_output,
+        Utf8,
+        Force_sf7,
+        Alternate_intro,
+        Rookie_mode);
+
+    if (n < 0 || (size_t)n >= sizeof(rc->flags)) {
+        debuglog("save_flags: flags buffer too small", 1);
+        free(rc);
+        return -1;
+    }
+
+    ret = write_sklaffrc(Uid, rc);
+
+    /*
+     * write_sklaffrc() currently frees rc on failure, but not on success.
+     * Only free it here after a successful write.
+     */
+    if (ret == 0)
+        free(rc);
+
+    return ret;
 }
 
 /*
@@ -263,16 +352,14 @@ check_flag(char *flags, char *flag)
 /*
  * turn_flag - set flag on or off
  * args: new value of flag (mode), flagname (flag)
- * ret: always 0
+ * ret: success (0) or failure (-1)
  */
 
 int
 turn_flag(int mode, char *flag)
 {
     int i;
-    LINE flags[22], outline, tmpline;
-    static HUGE_LINE newflags;
-    struct SKLAFFRC *rc;
+    LINE flags[22], outline;
 
     strcpy(flags[0], MSG_FLAG0);
     strcpy(flags[1], MSG_FLAG1);
@@ -316,6 +403,8 @@ turn_flag(int mode, char *flag)
             }
         }
         Ibm = mode;
+        if (mode)
+            Force_sf7 = 0;
         strcpy(outline, MSG_FLAG0F);
     } else if ((strstr(flags[1], flag) == flags[1]) && (i >= MSG_FLAG1N)) {
         if (mode && (Ibm || Mac || Utf8)) {
@@ -331,6 +420,8 @@ turn_flag(int mode, char *flag)
             }
         }
         Iso8859 = mode;
+        if (mode)
+            Force_sf7 = 0;
         strcpy(outline, MSG_FLAG1F);
     } else if ((strstr(flags[2], flag) == flags[2]) && (i >= MSG_FLAG2N)) {
         if (mode && (Ibm || Iso8859 || Utf8)) {
@@ -346,6 +437,8 @@ turn_flag(int mode, char *flag)
             }
         }
         Mac = mode;
+        if (mode)
+            Force_sf7 = 0;
         strcpy(outline, MSG_FLAG2F);
     } else if ((strstr(flags[3], flag) == flags[3]) && (i > MSG_FLAG3N)) {
         Present = mode;
@@ -409,6 +502,8 @@ turn_flag(int mode, char *flag)
             }
         }
         Utf8 = mode;
+        if (mode)
+            Force_sf7 = 0;
         strcpy(outline, MSG_FLAG19F);
 
     } else if ((strstr(flags[20], flag) == flags[20]) && (i >= MSG_FLAG20N)) {
@@ -423,53 +518,8 @@ turn_flag(int mode, char *flag)
         return 0;
     }
 
-    rc = read_sklaffrc(Uid);
-
-    sprintf(newflags, "say = %d\n", Say);
-    sprintf(tmpline, "shout = %d\n", Shout);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "present = %d\n", Present);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "ibm = %d\n", Ibm);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "iso8859 = %d\n", Iso8859);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "mac = %d\n", Mac);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "subject_change = %d\n", Subject_change);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "end_default = %d\n", End_default);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "space = %d\n", Space);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "copy = %d\n", Copy);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "author = %d\n", Author);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "date = %d\n", Date);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "beep = %d\n", Beep);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "clear = %d\n", Clear);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "header = %d\n", Header);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "strip = %d\n", Special);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "presbeep = %d\n", Presbeep);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "oldwho = %d\n", Old_who);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "ansi = %d\n", Ansi_output);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "utf8 = %d\n", Utf8);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "alternate_intro = %d\n", Alternate_intro);
-    strcat(newflags, tmpline);
-    sprintf(tmpline, "rookie_mode = %d\n", Rookie_mode);
-    strcat(newflags, tmpline);
-    strcpy(rc->flags, newflags);
-    write_sklaffrc(Uid, rc);
+    if (save_flags() == -1)
+        return -1;
     output("\n%s %s ", MSG_FLAG, outline);
     if (mode) {
         output("%s\n\n", MSG_FLON);

--- a/flag.c
+++ b/flag.c
@@ -220,6 +220,13 @@ set_flags(char *flags)
             Rookie_mode = atoi(i);
         } else
             Rookie_mode = 1;  /* default on */
+        p = strstr(flags, "start_mailbox");
+        if (p) {
+            i = strchr(p, '=');
+            i++;
+            Start_mailbox = atoi(i);
+        } else
+            Start_mailbox = 0; /* default off */
     } else {
         Shout = 1;
         Say = 1;
@@ -244,6 +251,7 @@ set_flags(char *flags)
         Force_sf7 = 0;
         Alternate_intro = 0;
         Rookie_mode = 1;
+        Start_mailbox = 0;
     }
 }
 
@@ -286,7 +294,8 @@ save_flags(void)
         "utf8 = %d\n"
         "force_sf7 = %d\n"
         "alternate_intro = %d\n"
-        "rookie_mode = %d\n",
+        "rookie_mode = %d\n"
+        "start_mailbox = %d\n",
         Say,
         Shout,
         Present,
@@ -309,7 +318,8 @@ save_flags(void)
         Utf8,
         Force_sf7,
         Alternate_intro,
-        Rookie_mode);
+        Rookie_mode,
+        Start_mailbox);
 
     if (n < 0 || (size_t)n >= sizeof(rc->flags)) {
         debuglog("save_flags: flags buffer too small", 1);
@@ -359,7 +369,7 @@ int
 turn_flag(int mode, char *flag)
 {
     int i;
-    LINE flags[22], outline;
+    LINE flags[23], outline;
 
     strcpy(flags[0], MSG_FLAG0);
     strcpy(flags[1], MSG_FLAG1);
@@ -383,6 +393,7 @@ turn_flag(int mode, char *flag)
     strcpy(flags[19], MSG_FLAG19);
     strcpy(flags[20], MSG_FLAG20);
     strcpy(flags[21], MSG_FLAG21);
+    strcpy(flags[22], MSG_FLAG22);
     if (!flag || (*flag == '\0')) {
         output("\n%s\n\n", MSG_NOFLAG);
         return 0;
@@ -512,7 +523,9 @@ turn_flag(int mode, char *flag)
     } else if ((strstr(flags[21], flag) == flags[21]) && (i >= MSG_FLAG21N)) {
         Rookie_mode = mode;
         strcpy(outline, MSG_FLAG21F);
-
+    } else if ((strstr(flags[22], flag) == flags[22]) && (i >= MSG_FLAG22N)) {
+        Start_mailbox = mode;
+        strcpy(outline, MSG_FLAG22F);
     } else {
         output("\n%s\n\n", MSG_BADFLAG);
         return 0;

--- a/globals.h
+++ b/globals.h
@@ -90,6 +90,7 @@ int Special;                    /* Special use, e.g. GUI client  */
 int Presbeep;                   /* Beep at present msg        	 */
 int Ansi_output;                /* Allow display of ANSI colors  */
 int Utf8;                       /* UTF-8 mode			 */
+int Force_sf7;					/* SF7 selection during login (hidden flag) */
 int Alternate_intro;            /* Re-arranged intro screen */
 int Rookie_mode;				/* Extra help for new users */
 

--- a/globals.h
+++ b/globals.h
@@ -93,7 +93,7 @@ int Utf8;                       /* UTF-8 mode			 */
 int Force_sf7;					/* SF7 selection during login (hidden flag) */
 int Alternate_intro;            /* Re-arranged intro screen */
 int Rookie_mode;				/* Extra help for new users */
-
+int Start_mailbox;				/* Always start in Mailbox during login */
 struct termios Tty_mode;
 sigset_t Oldmask;
 

--- a/lang.h
+++ b/lang.h
@@ -505,7 +505,7 @@
 #define MSG_FLAG4F	"(Till}t) skrik"
 #define MSG_FLAG5	"sluta"
 #define MSG_FLAG5N	2
-#define MSG_FLAG5F	"Sluta (som default)"
+#define MSG_FLAG5F	"Sluta (f|resl}s n{r du {r ikapp)"
 #define MSG_FLAG6	"s{g"
 #define MSG_FLAG6N	2
 #define MSG_FLAG6F	"(Till}t) s{g"
@@ -520,10 +520,10 @@
 #define MSG_FLAG9F	"Kopia (av s{nda brev)"
 #define MSG_FLAG10	"f|rfattare"
 #define MSG_FLAG10N	1
-#define MSG_FLAG10F	"F|rfattare (efter text)"
+#define MSG_FLAG10F	"F|rfattare (alltid efter text)"
 #define MSG_FLAG11	"datum"
 #define MSG_FLAG11N	1
-#define MSG_FLAG11F	"Datum (i texthuvud)"
+#define MSG_FLAG11F	"Datum (alltid absolut i texthuvud)"
 #define MSG_FLAG12	"pip"
 #define MSG_FLAG12N	1
 #define MSG_FLAG12F	"(Till}t) pip"
@@ -532,15 +532,10 @@
 #define MSG_FLAG13F	"Rensa (sk{rmen f|re varje text)"
 #define MSG_FLAG14	"header"
 #define MSG_FLAG14N	1
-#define MSG_FLAG14F	"Header (vid l{sning av email/news)"
-/*
-#define MSG_FLAG15	"strippa"
-#define MSG_FLAG15N	2
-#define MSG_FLAG15F	"Strippa (bit 8 vid inmatning)"
-*/
-#define MSG_FLAG15	"om|jligt"
-#define MSG_FLAG15N	1
-#define MSG_FLAG15F	"Om|jligt (speciall{ge)"
+#define MSG_FLAG14F	"Header (vid l{sning av e-post/news/FTN)"
+#define MSG_FLAG15	"kompatibilitet"
+#define MSG_FLAG15N	3
+#define MSG_FLAG15F	"Kompatibilitet (f|r specialklienter)"
 #define MSG_FLAG16	"bell"
 #define MSG_FLAG16N	1
 #define MSG_FLAG16F	"Bell (vid n{rvaromeddelanden)"
@@ -1278,7 +1273,7 @@
 #define MSG_FLAG4F	"(Allow) shouting"
 #define MSG_FLAG5	"logout"
 #define MSG_FLAG5N	1
-#define MSG_FLAG5F	"Logout (as default)"
+#define MSG_FLAG5F	"Logout (suggested when caught up)"
 #define MSG_FLAG6	"tell"
 #define MSG_FLAG6N	1
 #define MSG_FLAG6F	"(Allow) tell"
@@ -1293,10 +1288,10 @@
 #define MSG_FLAG9F	"Copy (of mail sent)"
 #define MSG_FLAG10	"author"
 #define MSG_FLAG10N	1
-#define MSG_FLAG10F	"Author (after text)"
+#define MSG_FLAG10F	"Author (always shown after text)"
 #define MSG_FLAG11	"date"
 #define MSG_FLAG11N	1
-#define MSG_FLAG11F	"Date (i textheader)"
+#define MSG_FLAG11F	"Date (always absolute in text header)"
 #define MSG_FLAG12	"beeps"
 #define MSG_FLAG12N	3
 #define MSG_FLAG12F	"(Allow) beeps"
@@ -1305,7 +1300,7 @@
 #define MSG_FLAG13F	"Clear (screen before textdisplay)"
 #define MSG_FLAG14	"header"
 #define MSG_FLAG14N	1
-#define MSG_FLAG14F	"Header (when reading email/news)"
+#define MSG_FLAG14F	"Header (when reading email/news/FTN)"
 #define MSG_FLAG15	"compatibility"
 #define MSG_FLAG15N	3
 #define MSG_FLAG15F	"Compatibility (mode for special clients)"

--- a/lang.h
+++ b/lang.h
@@ -578,6 +578,9 @@
 #define MSG_FLAG21  "rookie"
 #define MSG_FLAG21N 2
 #define MSG_FLAG21F "(Jag {r en) rookie"
+#define MSG_FLAG22  "brevl}dan"
+#define MSG_FLAG22N 3
+#define MSG_FLAG22F "(B|rja alltid i) Brevl}dan"
 #define MSG_NOFLAG	"Du m}ste ange en flagga."
 #define MSG_PCWARN	"Du b|r sl} av IBM-PC f|rst."
 #define MSG_ISOWARN	"Du b|r sl} av ISO 8859-1 f|rst."
@@ -1368,6 +1371,9 @@
 #define MSG_FLAG21  "rookie"
 #define MSG_FLAG21N 1
 #define MSG_FLAG21F "Rookie mode"
+#define MSG_FLAG22  "mailbox"
+#define MSG_FLAG22N 3
+#define MSG_FLAG22F "(Always start in) Mailbox"
 #define MSG_NOFLAG	"You must supply a flagname."
 #define MSG_PCWARN	"You should turn off IBM-PC first."
 #define MSG_ISOWARN	"You should turn off ISO 8859-1 first."

--- a/lang.h
+++ b/lang.h
@@ -112,15 +112,39 @@
 #define MSG_LESSMIN "mindre {n en minut."
 
 /* Alternativ startskärm */
-#define MSG_INTRO_CONTINUE "Tryck ENTER för att gå vidare..."
+#define MSG_INTRO_CONTINUE "Tryck ENTER f|r att g} vidare..."
 #define MSG_ALT_NOUNREAD "Du har inga nya texter."
 #define MSG_ALT_ONEUNREAD "Du har en ny text."
 #define MSG_ALT_YOU_HAVE "Du har"
 #define MSG_ALT_UNREADTEXTS "nya texter."
-#define MSG_ALT_COPYRIGHT "Copyright (C) 1993-1996 SklaffKOMs upphovsmän. GNU GPL 2+, utan garanti."
-#define MSG_ALT_LICENSE "Skriv visa licens för fullständiga villkor."
-#define MSG_ALT_DEDICATION "Programmet är tillägnat Staffan Bergströms minne."
+#define MSG_ALT_COPYRIGHT "Copyright (C) 1993-1996 SklaffKOMs upphovsm{n. GNU GPL 2+, utan garanti."
+#define MSG_ALT_LICENSE "Skriv visa licens f|r fullst{ndiga villkor."
+#define MSG_ALT_DEDICATION "Programmet {r till{gnat Staffan Bergstr|ms minne."
 #define MSG_ALT_ROOKIE_TIP01 "Tips! Tryck ENTER f|r att l{sa ol{sta texter. Skriv hj{lp om du fastnar."
+
+/* Välja teckentabell vid login */
+#define MSG_CHARSET_MENU \
+    "Valkommen till SklaffKOM!\n\n" \
+    "Innan vi borjar maste SklaffKOM och din terminal tala samma\n" \
+    "teckensprak.\n\n" \
+    "  1. UTF-8\n" \
+    "     Moderna terminaler, SSH och de flesta telnetklienter.\n\n" \
+    "  2. IBM CP437\n" \
+    "     Klassiska BBS-klienter som SyncTERM och NetRunner.\n\n" \
+    "  3. ISO-8859-1\n" \
+    "     Vanligast pa Amiga.\n\n" \
+    "  4. Klassiskt SklaffKOM-lage\n" \
+    "     Behall SF7 utan teckenkonvertering.\n\n"
+#define MSG_CHARSET_PROMPT 		"Vilket teckensprak talar din terminal? (1): "
+#define MSG_CHARSET_BAD_CHOICE	"Skriv 1, 2, 3 eller 4."
+#define MSG_CHARSET_TEST		"Din terminal ska nu visa:"
+#define MSG_CHARSET_CONFIRM 	"Ser det riktigt ut? (Ja/Nej): "
+#define MSG_CHARSET_BAD_CONFIRM "Svara Ja eller Nej."
+#define MSG_CHARSET_RETRY 		"D} provar vi igen."
+#define MSG_CHARSET_OK 			"Utm{rkt! Nu f|rst}r vi varandra."
+#define MSG_CHARSET_SAVE_FAILED \
+    "Kunde inte spara valet. Teckentabellen anv{nds under denna session,\n" \
+    "men du kommer att f} v{lja igen n{sta g}ng."
 
 /* bbslink.c */
 
@@ -868,9 +892,31 @@
 #define MSG_ALT_UNREADTEXTS "new articles."
 #define MSG_ALT_COPYRIGHT "Copyright (C) 1993-1996 the SklaffKOM authors. GNU GPL 2+, no warranty."
 #define MSG_ALT_LICENSE "Type show license for the full terms."
-#define MSG_ALT_DEDICATION "The program is dedicated to the memory of Staffan Bergström."
+#define MSG_ALT_DEDICATION "The program is dedicated to the memory of Staffan Bergstr|m."
 #define MSG_ALT_ROOKIE_TIP01 "Tip! Just press ENTER to read unread posts. Type help if you get stuck."
-
+/* charset during login */
+#define MSG_CHARSET_MENU \
+    "Welcome to SklaffKOM!\n\n" \
+    "Before we begin, SklaffKOM and your terminal need to speak the\n" \
+    "same character language.\n\n" \
+    "  1. UTF-8\n" \
+    "     Modern terminals, SSH, and most telnet clients.\n\n" \
+    "  2. IBM CP437\n" \
+    "     Classic BBS clients such as SyncTERM and NetRunner.\n\n" \
+    "  3. ISO-8859-1\n" \
+    "     Most commonly used on the Amiga.\n\n" \
+    "  4. Classic SklaffKOM mode\n" \
+    "     Keep SF7 without character conversion.\n\n"
+#define MSG_CHARSET_PROMPT 		"Which character language does your terminal speak? (1): "
+#define MSG_CHARSET_BAD_CHOICE 	"Please enter 1, 2, 3 or 4."
+#define MSG_CHARSET_TEST 		"Your terminal should now display:"
+#define MSG_CHARSET_CONFIRM 	"Does that look right? (Yes/No): "
+#define MSG_CHARSET_BAD_CONFIRM "Please answer Yes or No."
+#define MSG_CHARSET_RETRY		"Let's try again."
+#define MSG_CHARSET_OK 			"Excellent! Now we understand each other."
+#define MSG_CHARSET_SAVE_FAILED \
+    "The choice could not be saved. It will be used for this session,\n" \
+    "but you will be asked again next time."
 
 /* bbslink.c */
 #define MSG_BBSLINK01 "BBSLink is a door server with nearly 150 BBS'es connected."

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -8,7 +8,7 @@
  *
  *   Program dedicated to the memory of Staffan Bergstr|m.
  *
- *   For questions about this program, mail sklaff@sklaffkom.se    
+ *   For questions about this program, mail sklaff@sklaffkom.se
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -409,4 +409,157 @@ display_credits(void)
     output(MSG_VERSIONC2"\n");
     output(MSG_VERSIONC3"\n\n");
     output(MSG_CPY6); /* Till{gnat... */
+}
+
+/*
+ * reset_charset_flags - return to untranslated SF7 output
+ */
+
+static void
+reset_charset_flags(void)
+{
+    Utf8 = 0;
+    Ibm = 0;
+    Iso8859 = 0;
+    Mac = 0;
+    Force_sf7 = 0;
+}
+
+
+/*
+ * set_charset_choice - activate exactly one character set
+ */
+
+static void
+set_charset_choice(int choice)
+{
+    reset_charset_flags();
+
+    switch (choice) {
+    case 1:
+        Utf8 = 1;
+        break;
+
+    case 2:
+        Ibm = 1;
+        break;
+
+    case 3:
+        Iso8859 = 1;
+        break;
+    case 4:
+        Force_sf7 = 1;
+        break;
+    }
+}
+
+
+/*
+ * first_answer_char - return first non-whitespace character
+ */
+
+static int
+first_answer_char(const char *answer)
+{
+    const unsigned char *p;
+
+    if (answer == NULL)
+        return '\0';
+
+    p = (const unsigned char *)answer;
+
+    while (*p && isspace(*p))
+        p++;
+
+    return tolower(*p);
+}
+
+
+/*
+ * select_charset - first-login handshake between SklaffKOM and terminal
+ *
+ * The first menu deliberately contains ASCII only. After a choice has
+ * been made, the global character-set flag is temporarily activated and
+ * a Swedish test line is displayed using normal SF7 translation.
+ */
+
+int
+select_charset(void)
+{
+    LINE answer;
+    int choice;
+    int c;
+
+    for (;;) {
+        /*
+         * The menu must always be emitted without SF7 conversion.
+         */
+        reset_charset_flags();
+        clear_screen();
+
+        output("%s", MSG_CHARSET_MENU);
+
+        for (;;) {
+            output("%s", MSG_CHARSET_PROMPT);
+            input("", answer, LINE_LEN, 0, 0, 0);
+
+            c = first_answer_char(answer);
+
+            if (c == '\0') {
+                choice = 1;             /* ENTER defaults to UTF-8 */
+                break;
+            }
+
+            if (c >= '1' && c <= '4') {
+                choice = c - '0';
+                break;
+            }
+
+            output("\n%s\n\n", MSG_CHARSET_BAD_CHOICE);
+        }
+
+        /*
+         * output() now converts SF7 according to the selected flag.
+         */
+        set_charset_choice(choice);
+
+        output("\n%s\n\n", MSG_CHARSET_TEST);
+
+        /*
+         * SF7:
+         *   } = å   { = ä   | = ö
+         *   ] = Å   [ = Ä   \ = Ö
+         */
+        output("  } { |   ] [ %c\n\n", '\\');
+
+        for (;;) {
+            output("%s", MSG_CHARSET_CONFIRM);
+            input("", answer, LINE_LEN, 0, 0, 0);
+
+            c = first_answer_char(answer);
+
+            /*
+             * Accept both Swedish and English answers in either build.
+             */
+            if (c == 'j' || c == 'y') {
+                if (save_flags() == -1) {
+                    output("\n%s\n\n", MSG_CHARSET_SAVE_FAILED);
+                    return -1;
+                }
+
+                output("\n%s\n", MSG_CHARSET_OK);
+                sleep(1);
+                clear_screen();
+                return 0;
+            }
+
+            if (c == 'n') {
+                output("\n%s\n", MSG_CHARSET_RETRY);
+                sleep(1);
+                break;
+            }
+
+            output("\n%s\n\n", MSG_CHARSET_BAD_CONFIRM);
+        }
+    }
 }

--- a/sklaff.h
+++ b/sklaff.h
@@ -35,6 +35,12 @@
 #define SWEDISH
 //#define ENGLISH
 
+/* Enable (1) or disable (0) the character-set handshake at login. */
+
+#ifndef ENABLE_CHARSET_HANDSHAKE
+#define ENABLE_CHARSET_HANDSHAKE 0
+#endif
+
 /* Define group ids and terminaltypes for modem_pool */
 
 #define MODEM_POOL 	"silly"
@@ -431,7 +437,7 @@ const char *time_string_static(time_t t);                                       
 const char *month_name_sv(const char *mon);												/* 2026-06-04 PL nicer output in new "version" command */
 int sender_is_blocked(const char *blocklist, const char *sender); /* modified on 2026-06-16, PL */
 void display_credits(void);											/* 2026-08-01 display SklaffKOM authors etc inside "version" command and during logout */
-
+int select_charset(void);											/* 2026-08-05 lets user select charset during login */
 // enable the function below when ready and uncomment in conf.c
 //int has_file_area(int confnum);															/* 2025-11-11 PL */
 
@@ -629,6 +635,7 @@ int rebuild_index_file(void);
 void set_flags(char *);
 int check_flag(char *, char *);
 int turn_flag(int, char *);
+int save_flags(void);	/* PL 2026-08-05 improved save_flags procedure */
 
 /* footnote.c */
 


### PR DESCRIPTION
* New users now get prompted to chose a character set during login. This is only displayed once for each user. Like so :

```
Valkommen till SklaffKOM!

Innan vi borjar maste SklaffKOM och din terminal tala samma
teckensprak.

  1. UTF-8
     Moderna terminaler, SSH och de flesta telnetklienter.

  2. IBM CP437
     Klassiska BBS-klienter som SyncTERM och NetRunner.

  3. ISO-8859-1
     Vanligt pa Amiga och i aldre terminalprogram.

  4. Klassiskt SklaffKOM-lage
     Behall SF7 utan teckenkonvertering.

Vilket teckensprak talar din terminal? (1):1

Din terminal ska nu visa:

  å ä ö   Å Ä Ö

Ser det riktigt ut? (Ja/Nej): Ja

(clearscreen)

Välkommen till SklaffKOM .....
```
Since I have not yet tested this feature enough, I made sure there's a way to disable it : 
```

/* Enable (1) or disable (0) the character-set handshake at login. */           
                                                                                
#ifndef ENABLE_CHARSET_HANDSHAKE                                                
#define ENABLE_CHARSET_HANDSHAKE 0                                              
#endif 
```

It's disabled by default. Change the above value to "1" to enable.

* A new flag "(Börja alltid i) Brevlådan" puts user in the mailbox first, during login, regardless if they mailbox is empty or not. If there are unread texts in other conferences, the prompt suggests going there. This is they way NiKom (and Mikrokom for that matter) does it, and I'm used to that. Sklaffkom's default behaviour is to immediately go to the next conference with unread texts. I never really got used to that... but now I feel right at home again haha.

Enjoy!

Peter