### PR TITLE
Version bump, features & fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ ftntoss
 color-test.sh
 htmlmsgdump
 ibolmsgdump
+ibolimport

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ color-test.sh
 htmlmsgdump
 ibolmsgdump
 ibolimport
+dist/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+v1.33-rc2 Thursday 13 August 2026
+
+* Time for a version bump. New command "Wall" / "Väggen" displays InterBBS
+  OneLiners if configured correctly. Supposed to be at logout eventually
+  (optional, behind a flag setting).
+
 v1.33-rc1 Sunday 02 August 2026 PL
 
 * Numerous small fixes. Code cleanup. Praise / Unpraise blocked in ftn, as
@@ -25,6 +31,13 @@ v1.33-rc1 Sunday 02 August 2026 PL
 
 * Character set "handshake" during login for users who did not yet pick a
   charset flag. Only displayed once. Meant for new users.
+
+* New command "Edit conference (settings) / "Ändra möte". Also "Create 
+  conference" got some new features.
+
+* Laid the groundwork for separate transport / access settings in all
+  conferences, to allow for secret or hidden usenet and FTN meetings. Nothing
+  in the UI indicates this yet, still in early testing phase.
 
 v1.33-rc1 Saturday 06 June 2026 JM
 

--- a/Makefile
+++ b/Makefile
@@ -158,18 +158,19 @@ install: sklaffkom sklaffadm sklaffacct survreport sklaffwho newstoss ftntoss
 	chmod u+s $(SKLAFFBIN)/sklaffkom $(SKLAFFBIN)/sklaffacct $(SKLAFFBIN)/sklaffwho
 	chmod og-rxw $(SKLAFFBIN)/sklaffadm
 	-chmod 4755   $(SKLAFFBIN)/srep
-	cp newstoss mailtoss ftntoss $(SKLAFFDIR)/etc
+	cp newstoss mailtoss ftntoss ibolimport $(SKLAFFDIR)/etc
 	cp newstoss $(SKLAFFDIR)/etc/ntoss
 	cp mailtoss $(SKLAFFDIR)/etc/mtoss
 	# Better copy mailtoss and newstoss to sklaffbin also
 	cp mailtoss $(SKLAFFBIN)
 	cp newstoss $(SKLAFFBIN)
 	cp ftntoss $(SKLAFFBIN)
+	cp ibolimport $(SKLAFFBIN)
 	cp etc/ftnqueue-runner $(SKLAFFBIN)/ftnqueue-runner
 	chown root $(SKLAFFBIN)/ftnqueue-runner
 	chmod 755 $(SKLAFFBIN)/ftnqueue-runner
-	-chown root $(SKLAFFDIR)/etc/newstoss $(SKLAFFDIR)/etc/ntoss $(SKLAFFDIR)/etc/mailtoss $(SKLAFFDIR)/etc/mtoss $(SKLAFFDIR)/etc/ftntoss
-	-chmod og-rxw $(SKLAFFDIR)/etc/newstoss $(SKLAFFDIR)/etc/ntoss $(SKLAFFDIR)/etc/mailtoss $(SKLAFFDIR)/etc/mtoss $(SKLAFFDIR)/etc/ftntoss
+	-chown root $(SKLAFFDIR)/etc/newstoss $(SKLAFFDIR)/etc/ntoss $(SKLAFFDIR)/etc/mailtoss $(SKLAFFDIR)/etc/mtoss $(SKLAFFDIR)/etc/ftntoss $(SKLAFFDIR)/etc/ibolimport
+	-chmod og-rxw $(SKLAFFDIR)/etc/newstoss $(SKLAFFDIR)/etc/ntoss $(SKLAFFDIR)/etc/mailtoss $(SKLAFFDIR)/etc/mtoss $(SKLAFFDIR)/etc/ftntoss $(SKLAFFDIR)/etc/ibolimport
 installdb:
 	@echo Installing datafiles
 	-mkdir $(SKLAFFDIR)

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ OBJS = \
 	file.o \
 	footnote.o \
 	flag.o \
-	msg.o \
+    iboldb.o \
+    ibolview.o \
+    msg.o \
 	newsparse.o \
 	parse.o\
 	praise.o\

--- a/admin.c
+++ b/admin.c
@@ -1310,31 +1310,41 @@ if (st_type == STATUS_EXTERNAL)
 			}
 			free(desc);
 			output(MSG_CONFTYPE);
-            switch (ce->type) {
-            case OPEN_CONF:
-                output("%s\n", MSG_CONFDEFAULT);
-                break;
-            case CLOSED_CONF:
-                output("%s\n", MSG_CLOSED2);
-                break;
-            case SECRET_CONF:
-                output("%s\n", MSG_SECRET2);
-                break;
-            case NEWS_CONF:
-                output("%s\n", MSG_NEWS2);
-                break;
-            case FTN_CONF:
-                output("%s\n", MSG_FTN);
-                break;
-            default:
-                output("%s\n", MSG_UNKNOWNU);
-                break;
+            if (conf_is_news(ce->type)) {
+                output("%s", MSG_NEWS2);
+                if (conf_access_type(ce->type) == CLOSED_CONF)
+                    output(" / %s", MSG_CLOSED2);
+                else if (conf_access_type(ce->type) == SECRET_CONF)
+                    output(" / %s", MSG_SECRET2);
+                output("\n");
+            } else if (conf_is_ftn(ce->type)) {
+                output("%s", MSG_FTN);
+                if (conf_access_type(ce->type) == CLOSED_CONF)
+                    output(" / %s", MSG_CLOSED2);
+                else if (conf_access_type(ce->type) == SECRET_CONF)
+                    output(" / %s", MSG_SECRET2);
+                output("\n");
+            } else {
+                switch (conf_access_type(ce->type)) {
+                case OPEN_CONF:
+                    output("%s\n", MSG_CONFDEFAULT);
+                    break;
+                case CLOSED_CONF:
+                    output("%s\n", MSG_CLOSED2);
+                    break;
+                case SECRET_CONF:
+                    output("%s\n", MSG_SECRET2);
+                    break;
+                default:
+                    output("%s\n", MSG_UNKNOWNU);
+                    break;
+                }
             }
             /*
              * Show FTN routing information when this is an FTN conference
              * with a valid ftnconf file.
              */
-            if (ce->type == FTN_CONF) {
+            if (conf_is_ftn(ce->type)) {
                 ftn_found = 0;
 
                 if (conf_load_ftnconf(c_num, &ftnconf, &ftn_found) == 0 &&

--- a/command_list.c
+++ b/command_list.c
@@ -92,6 +92,7 @@ const struct COMMAND_ENTRY command_list[] = {
     { "cmd_unsubscribe", cmd_unsubscribe, },
     { "cmd_upload", cmd_upload, },
 	{ "cmd_version", cmd_version, },
+    { "cmd_wall", cmd_wall, },
     { "cmd_where", cmd_where, },
     { "cmd_who", cmd_who, },
     { "cmd_whole_text", cmd_whole_text, },

--- a/commands.c
+++ b/commands.c
@@ -6943,6 +6943,20 @@ cmd_jumpuser(char *args)
     long num, count;
     int fd, jumpuid;
     struct TEXT_ENTRY te;
+    struct CONF_ENTRY *ce;
+
+    /*
+     * External authors are not represented by ordinary local user IDs.
+     * Until cmd_jumpuser knows how to handle News/FTN authors properly,
+     * only allow it in local conferences.
+     */
+    if (Current_conf > 0) {
+        ce = get_conf_struct(Current_conf);
+        if (ce != NULL && conf_is_external(ce->type)) {
+            output("\n%s\n\n", MSG_JUMPUSERLOCAL);
+            return 0;
+        }
+    }
 
     if (args && *args) {
         expname = expand_name(args, USER, 0, NULL);

--- a/commands.c
+++ b/commands.c
@@ -1393,14 +1393,8 @@ cmd_list_rights(char *args)
 }
 
 static int
-conf_type_from_char(int c)
+conf_transport_from_char(int c)
 {
-    if (c == MSG_CONFCLOSED)
-        return CLOSED_CONF;
-
-    if (c == MSG_CONFSECRET)
-        return SECRET_CONF;
-
     if (c == MSG_CONFNEWS)
         return NEWS_CONF;
 
@@ -1412,35 +1406,51 @@ conf_type_from_char(int c)
 
 
 static int
-conf_type_to_char(int type)
+conf_transport_to_char(int transport)
 {
-    if (conf_is_news(type))
+    if (transport == NEWS_CONF)
         return MSG_CONFNEWS;
 
-    if (conf_is_ftn(type))
+    if (transport == FTN_CONF)
         return MSG_CONFFTN;
 
-    switch (conf_access_type(type)) {
-    case CLOSED_CONF:
-        return MSG_CONFCLOSED;
-
-    case SECRET_CONF:
-        return MSG_CONFSECRET;
-
-    case OPEN_CONF:
-    default:
-        return MSG_CONFOPEN;
-    }
+    return MSG_CONFLOCAL;
 }
 
 
 static int
-prompt_conf_type(int current_type)
+conf_access_from_char(int c)
+{
+    if (c == MSG_CONFCLOSED)
+        return CLOSED_CONF;
+
+    if (c == MSG_CONFSECRET)
+        return SECRET_CONF;
+
+    return OPEN_CONF;
+}
+
+
+static int
+conf_access_to_char(int access)
+{
+    if (access == CLOSED_CONF)
+        return MSG_CONFCLOSED;
+
+    if (access == SECRET_CONF)
+        return MSG_CONFSECRET;
+
+    return MSG_CONFOPEN;
+}
+
+
+static int
+prompt_conf_transport(int current_transport)
 {
     LINE interact;
     char def[2];
 
-    def[0] = (char)conf_type_to_char(current_type);
+    def[0] = (char)conf_transport_to_char(current_transport);
     def[1] = '\0';
 
     output(MSG_CONFTPROMPT);
@@ -1448,18 +1458,57 @@ prompt_conf_type(int current_type)
     down_string(interact);
 
     if (*interact == '\0')
-        return current_type;
+        return current_transport;
 
-    /*
-     * input() may return the displayed default character when ENTER is used.
-     * Preserve a combined NEWS/FTN access type when its transport did not
-     * actually change.  The separate transport/access UI comes in phase 2.
-     */
-    if ((interact[0] == MSG_CONFNEWS && conf_is_news(current_type)) ||
-        (interact[0] == MSG_CONFFTN && conf_is_ftn(current_type)))
-        return current_type;
+    return conf_transport_from_char((unsigned char)interact[0]);
+}
 
-    return conf_type_from_char((unsigned char)interact[0]);
+
+static int
+prompt_conf_access(int current_access)
+{
+    LINE interact;
+    char def[2];
+
+    def[0] = (char)conf_access_to_char(current_access);
+    def[1] = '\0';
+
+    output(MSG_CONFACCESSPROMPT);
+    input(def, interact, LINE_LEN, 0, 0, 0);
+    down_string(interact);
+
+    if (*interact == '\0')
+        return current_access;
+
+    return conf_access_from_char((unsigned char)interact[0]);
+}
+
+
+static int
+prompt_conf_type(int current_type)
+{
+    int transport;
+    int access;
+    int type;
+
+    transport = conf_transport_type(current_type);
+    access = conf_access_type(current_type);
+
+    if (transport < 0)
+        transport = OPEN_CONF;
+
+    if (access < 0)
+        access = OPEN_CONF;
+
+    transport = prompt_conf_transport(transport);
+    access = prompt_conf_access(access);
+
+    type = conf_make_type(transport, access);
+
+    if (type < 0)
+        return OPEN_CONF;
+
+    return type;
 }
 
 

--- a/commands.c
+++ b/commands.c
@@ -1341,7 +1341,7 @@ cmd_list_rights(char *args)
     ul = get_confrc_struct(confnum);
     ce = get_conf_struct(confnum);
 
-    if ((ce->type == OPEN_CONF) || (ce->type == NEWS_CONF)) {
+    if (conf_access_type(ce->type) == OPEN_CONF) {
         output("\n%s %s:\n\n", MSG_NORIGHTS, ce->name);
     } else {
         output("\n%s %s:\n\n", MSG_YESRIGHTS, ce->name);
@@ -1414,18 +1414,18 @@ conf_type_from_char(int c)
 static int
 conf_type_to_char(int type)
 {
-    switch (type) {
+    if (conf_is_news(type))
+        return MSG_CONFNEWS;
+
+    if (conf_is_ftn(type))
+        return MSG_CONFFTN;
+
+    switch (conf_access_type(type)) {
     case CLOSED_CONF:
         return MSG_CONFCLOSED;
 
     case SECRET_CONF:
         return MSG_CONFSECRET;
-
-    case NEWS_CONF:
-        return MSG_CONFNEWS;
-
-    case FTN_CONF:
-        return MSG_CONFFTN;
 
     case OPEN_CONF:
     default:
@@ -1448,6 +1448,15 @@ prompt_conf_type(int current_type)
     down_string(interact);
 
     if (*interact == '\0')
+        return current_type;
+
+    /*
+     * input() may return the displayed default character when ENTER is used.
+     * Preserve a combined NEWS/FTN access type when its transport did not
+     * actually change.  The separate transport/access UI comes in phase 2.
+     */
+    if ((interact[0] == MSG_CONFNEWS && conf_is_news(current_type)) ||
+        (interact[0] == MSG_CONFFTN && conf_is_ftn(current_type)))
         return current_type;
 
     return conf_type_from_char((unsigned char)interact[0]);
@@ -1547,7 +1556,7 @@ cmd_create_conf(char *args)
         /*
          * FTN configuration is collected before anything is written.
          */
-        if (conf_type == FTN_CONF) {
+        if (conf_is_ftn(conf_type)) {
             conf_init_ftnconf(&ftnconf);
 
             if (prompt_ftnconf(&ftnconf) != 0)
@@ -1573,9 +1582,9 @@ cmd_create_conf(char *args)
                 break;
         }
 
-        if (conf_type == NEWS_CONF)
+        if (conf_is_news(conf_type))
             ce.life = EXP_DEF_NEWS;
-        else if (conf_type == FTN_CONF)
+        else if (conf_is_ftn(conf_type))
             ce.life = EXP_DEF_FTN;
         else
             ce.life = EXP_DEF;
@@ -1648,7 +1657,7 @@ cmd_create_conf(char *args)
         /*
          * Store FTN configuration for FTN conferences.
          */
-        if (conf_type == FTN_CONF) {
+        if (conf_is_ftn(conf_type)) {
             if (conf_write_ftnconf(ce.num, &ftnconf) != 0) {
                 dlog(2,
                     "cmd_create_conf: could not write ftnconf for conference %d",
@@ -1961,7 +1970,7 @@ cmd_add_rights(char *args)
                     if ((nbuf = (char *) malloc(i)) == NULL)
                         return -1;
                     memset(nbuf, 0, i);
-                    if ((ce->type > 0) && (ce->type < 3)) {
+                    if (conf_access_type(ce->type) != OPEN_CONF) {
                         snprintf(newuid, sizeof(newuid), "%d\n", unum);
                         strcpy(nbuf, buf);
                         strcat(nbuf, newuid);
@@ -2035,7 +2044,7 @@ cmd_sub_rights(char *args)
                         if ((nbuf = (char *) malloc(i)) == NULL)
                             return -1;
                         memset(nbuf, 0, i);
-                        if ((ce->type > 0) && (ce->type < 3)) {
+                        if (conf_access_type(ce->type) != OPEN_CONF) {
                             while (ul) {
                                 if (ul->num != unum) {
                                     snprintf(newuid, sizeof(newuid), "%d\n", ul->num);
@@ -2799,7 +2808,7 @@ cmd_personal(char *args)
     ftn_fromline[0] = '\0';
 
     ce = get_conf_struct(Current_conf);
-    if (ce != NULL && ce->type == FTN_CONF)
+    if (ce != NULL && conf_is_ftn(ce->type))
         is_ftn_conf = 1;
 
     if (is_ftn_conf) {
@@ -3108,14 +3117,14 @@ cmd_post_text(char *args)
     th.author = Uid;
     ce = get_conf_struct(confid);
 #ifndef POSTING_OK
-    if (ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+    if (conf_is_external(ce->type)) {
         dlog(5, "cmd_post_text: external conf but POSTING_OK not defined -> MSG_NONEWS");
         output("\n%s\n\n", MSG_NONEWS);
         return 0;
     }
 #endif
 #ifdef POSTING_OK
-    if (ce->type == NEWS_CONF) {
+    if (conf_is_news(ce->type)) {
         struct passwd *pw = getpwuid(Uid);
         snprintf(uname, sizeof(uname), "%s <%s@%s>",
     		user_name(Uid, tmp), pw->pw_name, MACHINE_NAME);
@@ -3137,9 +3146,9 @@ cmd_post_text(char *args)
     strcat(fname, EDIT_FILE);
     dlog(7, "cmd_post_text: edit file path=[%s]", fname);
     output("\n");
-    if (ce->type == NEWS_CONF)
+    if (conf_is_news(ce->type))
         show_post_warning(POST_INFO, "POST_INFO");
-    else if (ce->type == FTN_CONF)
+    else if (conf_is_ftn(ce->type))
         show_post_warning(POST_FTNINFO, "POST_FTNINFO");
     display_header(&th, 1, confid, 0, un);
     dlog(7, "cmd_post_text: header done, subject=[%s]", th.subject);
@@ -3566,14 +3575,14 @@ cmd_comment(char *args)
     thtmp = &te.th;
     commenttext = thtmp->num;
     commentuid = thtmp->author;
-	is_ftn_reply = 0;
+    is_ftn_reply = 0;
 
-	if (Current_conf > 0) {
-    	ce = get_conf_struct(Current_conf);
-    	if (ce != NULL) {
-        	is_ftn_reply = (ce->type == FTN_CONF);
-    	}
-	}
+    if (Current_conf > 0) {
+        ce = get_conf_struct(Current_conf);
+        if (ce != NULL) {
+            is_ftn_reply = conf_is_ftn(ce->type);
+        }
+    }
     dlog(6, "cmd_comment: replying to text=%ld author=%d subject=[%s]",
          commenttext, commentuid, thtmp->subject);
 
@@ -3732,7 +3741,7 @@ cmd_comment(char *args)
 #ifndef POSTING_OK
     if (nc > 0) {
         ce = get_conf_struct(nc);
-        if (ce != NULL && (ce->type == NEWS_CONF || ce->type == FTN_CONF)) {
+        if (ce != NULL && conf_is_external(ce->type)) {
             dlog(5, "cmd_comment: external conf but POSTING_OK not defined -> MSG_NONEWS");
             output("\n%s\n\n", MSG_NONEWS);
             return 0;
@@ -3744,9 +3753,9 @@ cmd_comment(char *args)
     if (nc > 0) {
         ce = get_conf_struct(nc);
 
-        if (ce != NULL && ce->type == NEWS_CONF)
+        if (ce != NULL && conf_is_news(ce->type))
             show_post_warning(POST_INFO, "POST_INFO");
-        else if (ce != NULL && ce->type == FTN_CONF)
+        else if (ce != NULL && conf_is_ftn(ce->type))
             show_post_warning(POST_FTNINFO, "POST_FTNINFO");
     }
 #endif
@@ -3764,7 +3773,7 @@ cmd_comment(char *args)
     /* News comment or local/mail branches */
     if (nc > 0) {
         ce = get_conf_struct(nc);
-        if (ce->type == NEWS_CONF) {
+        if (conf_is_news(ce->type)) {
             th.author = 0;
             dlog(6, "cmd_comment: NEWS reply mode (author=0)");
         }
@@ -7184,7 +7193,7 @@ cmd_post_survey(char *args)
     }
     th.author = Uid;
     ce = get_conf_struct(confid);
-    if (ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+    if (conf_is_external(ce->type)) {
         output("\n%s\n\n", MSG_NONEWS);
         return 0;
     }
@@ -7804,7 +7813,7 @@ cmd_footnote(char *args)
 
     struct CONF_ENTRY *ce = get_conf_struct(Current_conf);
 
-    if (!ce || ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+    if (!ce || conf_is_external(ce->type)) {
         output("\n" MSG_FOOTINLOCAL "\n\n");
         return 0;
     }
@@ -8003,7 +8012,7 @@ cmd_like(char *args)
 
     struct CONF_ENTRY *ce = get_conf_struct(Current_conf);
 
-    if (!ce || ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+    if (!ce || conf_is_external(ce->type)) {
         output("\n" MSG_PRAISELOCAL "\n\n");
         return 0;
     }
@@ -8149,7 +8158,7 @@ cmd_unlike(char *args)
 
     struct CONF_ENTRY *ce = get_conf_struct(Current_conf);
 
-    if (!ce || ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+    if (!ce || conf_is_external(ce->type)) {
         output("\n" MSG_PRAISELOCAL "\n\n");
         return 0;
     }
@@ -8648,7 +8657,7 @@ cmd_mod_conf(char *args)
     ftn_found = 0;
     ftn_changed = 0;
 
-    if (new_type == FTN_CONF) {
+    if (conf_is_ftn(new_type)) {
         if (conf_load_ftnconf(c_num, &ftnconf, &ftn_found) != 0) {
             output("\n%s\n\n", MSG_MODCONF_BADFTN);
             return 0;
@@ -8710,7 +8719,7 @@ cmd_mod_conf(char *args)
     /*
      * Only rewrite ftnconf when its contents actually changed.
      */
-    if (new_type == FTN_CONF && ftn_changed) {
+    if (conf_is_ftn(new_type) && ftn_changed) {
         if (conf_write_ftnconf(c_num, &ftnconf) != 0) {
             dlog(2,
                 "cmd_mod_conf: could not write ftnconf for conference %d",

--- a/commands.c
+++ b/commands.c
@@ -8764,3 +8764,23 @@ cmd_mod_conf(char *args)
 
     return 0;
 }
+
+int
+cmd_wall(char *args)
+{
+    if (args && *args) {
+        output("\n%s\n\n", MSG_NOARG);
+        return 0;
+    }
+
+
+    if (IBOL_LOGOUT_COUNT <= 0) {
+        output("\n%s\n\n", MSG_IBOL_DISABLED);
+        return 0;
+    }
+
+    if (display_ibol_entries(IBOL_LOGOUT_COUNT) >= 0)
+        (void)prompt_ibol_oneliner();
+
+    return 0;
+}

--- a/conf.c
+++ b/conf.c
@@ -259,9 +259,14 @@ int
 can_see_conf(int u_num, int c_num, int t_num, int cr_num)
 {
     int right;
+    int access;
     struct USER_LIST *ul;
 
-    if (t_num != SECRET_CONF)
+    access = conf_access_type(t_num);
+    if (access < 0)
+        return 0;
+
+    if (access != SECRET_CONF)
         return 1;
     if (cr_num == u_num)
         return 1;
@@ -269,7 +274,6 @@ can_see_conf(int u_num, int c_num, int t_num, int cr_num)
         return 1;
     }
     ul = get_confrc_struct(c_num);
-    right = 1;
     right = conf_right(ul, u_num, t_num, cr_num);
     free_userlist(ul);
     return ((right < 2) && (right >= 0));
@@ -1083,11 +1087,11 @@ if ((buf = get_conf_entry(buf, &ce))) {
         if (ce.creator == -1) continue;   /* erased */
         if (ce.num == 0)    continue;     /* mailbox already printed */
 
-        /* visibility like before */
-        int rights = ce.type;
-        if (rights == NEWS_CONF || rights == FTN_CONF)
-            rights = OPEN_CONF;
-        if (ce.creator == Uid) rights = 0;
+        /* Visibility is determined by access class, not transport. */
+        int rights = conf_access_type(ce.type);
+        if (rights < 0)
+            continue;
+        if (ce.creator == Uid) rights = OPEN_CONF;
         else if (rights == SECRET_CONF &&
                  !can_see_conf(Uid, ce.num, ce.type, ce.creator))
             continue;
@@ -1115,7 +1119,7 @@ if ((buf = get_conf_entry(buf, &ce))) {
             }
         n->unreads   = ur;
         n->next      = NULL;		
-		if (ce.type == FTN_CONF) {
+		if (conf_is_ftn(ce.type)) {
     /*
      * Group FTN conferences after local conferences, sorted alphabetically.
      *
@@ -1133,7 +1137,7 @@ if ((buf = get_conf_entry(buf, &ce))) {
         		n->next = p->next;
         		p->next = n;
     		}
-		} else if (ce.type == NEWS_CONF) {
+		} else if (conf_is_news(ce.type)) {
     	/*
      	* Group Usenet conferences last, sorted alphabetically.
      	*
@@ -1182,7 +1186,7 @@ if ((buf = get_conf_entry(buf, &ce))) {
             file_suffix = " (F)";
 
         /* modified on 2026-06-08, PL */
-        if (c->type == FTN_CONF)
+        if (conf_is_ftn(c->type))
             type_suffix = " (FTN)";
 
         output_ansi_fmt(
@@ -1245,10 +1249,14 @@ int
 conf_right(struct USER_LIST * ul, int uid, int type, int cr_num)
 {
     int xit;
+    int access;
 
-    xit = type;
-	if (xit == NEWS_CONF || xit == FTN_CONF) /* modified on 2026-06-11, PL */
-    	xit = OPEN_CONF;
+    access = conf_access_type(type);
+    if (access < 0)
+        return -1;
+
+    xit = access;
+
     if (cr_num == uid) {
         xit = 0;
     } else {
@@ -1260,7 +1268,11 @@ conf_right(struct USER_LIST * ul, int uid, int type, int cr_num)
         }
 
         if (ul && (ul->num == uid)) {
-            if ((type == OPEN_CONF) || (type == NEWS_CONF) || (type == FTN_CONF)) /* modified on 2026-06-11, PL */
+            /*
+             * For open conferences, confrc is a deny list.
+             * For closed/secret conferences, confrc is an allow list.
+             */
+            if (access == OPEN_CONF)
                 xit = 1;
             else
                 xit = 0;

--- a/edit.c
+++ b/edit.c
@@ -484,7 +484,7 @@ if (c == 0xC3) {
 #ifndef POSTING_OK
                 if (nc) {
                     ce = get_conf_struct(*nc);
-                    if (ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+                    if (conf_is_external(ce->type)) {
                         output("\n\n%s\n", MSG_NOSAVE);
                         ptr->line[len] = '\0';
                         output("\n%3d:%s", numlines, ptr->line);
@@ -797,7 +797,7 @@ if (c == 0xC3) {
                             newconf = conf_num(confname);
 #ifndef POSTING_OK
                             ce = get_conf_struct(newconf);
-                            if (ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+                            if (conf_is_external(ce->type)) {
                                 newconf = -1;
                             }
 #endif
@@ -849,7 +849,7 @@ if (c == 0xC3) {
 #ifndef POSTING_OK
                     if (nc) {
                         ce = get_conf_struct(*nc);
-                        if (ce->type == NEWS_CONF || ce->type == FTN_CONF) {
+                        if (conf_is_external(ce->type)) {
                             output("\n%s\n\n", MSG_NOSAVE);
                             marcel = 0;
                         }

--- a/etc/ftnqueue-runner
+++ b/etc/ftnqueue-runner
@@ -15,6 +15,21 @@ trap 'rmdir "$LOCK"' EXIT HUP INT TERM
 for job in "$PENDING"/*; do
     [ -f "$job" ] || continue
 
+    #
+    # IBOL jobs share the ordinary echomail queue, but are identified by
+    # filename and contain a typed multi-line job rather than conf:text:time.
+    #
+    # modified on 2026-08-13, PL
+    #
+    case "${job##*/}" in
+        @ibol.*)
+            if "$SKLAFFBIN/ftntoss" --export-ibol-job "$job" >/dev/null 2>&1; then
+                rm -f "$job"
+            fi
+            continue
+            ;;
+    esac
+
     IFS=: read conf_or_area textnum created < "$job" || continue
 
     case "$textnum" in

--- a/etc/help.eng/bbslink
+++ b/etc/help.eng/bbslink
@@ -1,0 +1,25 @@
+Arguments:
+  (<Game>)
+
+Description:
+  This command launches online games through the InterBBS-like service
+  BBSLink.net, a platform currently used by more than 140 active BBSes.
+  If the command is entered without an argument, a list of all available
+  games is displayed.
+
+Please note:
+  This feature requires a fair amount of configuration on the SysOp's
+  side. A good place to start is the following documentation:
+
+  https://github.com/loppanloppis/sklaffkom-dev/wiki/BBSLink
+
+Background:
+  Let's be honest - no matter how good Unix is, when it comes to BBS
+  door games, DOS is still king. We can of course use dosemu for this
+  purpose and launch suitable DOS games as external commands from our
+  BBS, but these days it would probably be difficult to gather more than
+  a handful of players on a single system.
+
+  With BBSLink, we can instead play alongside users from more than 100
+  other systems around the world. Hard to imagine back in 1993,
+  wasn't it? ;)

--- a/etc/help.eng/change_comc
+++ b/etc/help.eng/change_comc
@@ -1,0 +1,27 @@
+Arguments:
+  (<Conference>)
+
+Description:
+  This command lets the creator of a conference assign another
+  conference as its comment conference. A comment conference can be
+  used to place comments on texts in a separate conference, for example
+  if you want to keep information and the following discussion apart.
+
+  If no argument is given, the setting for your current conference is
+  changed. If a conference is given as an argument, that conference is
+  used instead. You will then be asked which existing conference should
+  be used as its comment conference.
+
+Please note:
+  Only the creator of a conference can change its comment conference.
+
+  If the conference itself is selected as its comment conference, the
+  link to a separate comment conference is removed.
+
+  This command cannot be used for the mailbox.
+
+Example:
+  To use "Discussion" as the comment conference for "Announcements":
+
+    -> change comment conference Announcements
+    New conference: Discussion

--- a/etc/help.eng/display_commented
+++ b/etc/help.eng/display_commented
@@ -1,0 +1,18 @@
+Arguments:
+  None
+
+Description:
+  Displays the text that the most recently read text is a comment on.
+  This is useful when you find yourself in the middle of a discussion
+  and want to go back and see what was actually being replied to.
+
+  If the previous text is itself a comment, you can use the command
+  again. In this way you can follow the discussion backwards, one step
+  at a time, all the way to the original text.
+
+  The command can also follow comments between different conferences,
+  provided that you have permission to read the conference.
+
+Please note:
+  If the most recently read text is not a comment, there is naturally
+  no previous text to display.

--- a/etc/help.eng/display_last
+++ b/etc/help.eng/display_last
@@ -1,2 +1,8 @@
+Arguments:
+  None
+
 Description:
-  Displays last article read again.
+  Displays the text you most recently looked at once again.
+
+  This also applies if you have temporarily jumped to another, older
+  text.

--- a/etc/help.eng/from
+++ b/etc/help.eng/from
@@ -1,0 +1,9 @@
+Arguments:
+  (<Location>)
+
+Description:
+  Sets the location you are logged in from. This is shown to other users
+  in the Who list and in your user status.
+
+  If the command is given without an argument, the value is reset to the
+  system hostname.

--- a/etc/help.eng/jumpuser
+++ b/etc/help.eng/jumpuser
@@ -1,0 +1,10 @@
+Arguments:
+  (<User>)
+
+Description:
+  Marks all unread texts written by a certain user in the current
+  conference as read.
+
+  If no user name is given, the author of the most recently read text
+  is used.
+

--- a/etc/help.eng/list_flags
+++ b/etc/help.eng/list_flags
@@ -1,2 +1,31 @@
 Description:
   List all your flags and their current value.
+
+  The first four flags select the character set used by your terminal:
+
+  UTF-8 (character set) - For most modern terminals.
+  IBM-PC (character set) - IBM CP437, common in DOS terminals.
+  ISO 8859-1 (character set) - Latin-1, commonly used with Amiga terminals.
+  Macintosh (character set) - For older Macintosh terminals.
+
+  The remaining flags control other SklaffKOM behaviour:
+
+  (Show) presence messages - Shows when users log in or out.
+  (Allow) shouting - Allows messages sent to all logged-in users.
+  Logout (suggested when caught up) - Suggests Logout when there is nothing to read.
+  (Allow) tell - Allows personal messages from other users.
+  Subject change (when replying) - Allows changing the subject when replying.
+  Space (equals CR) - Space works like Enter at the prompt.
+  Copy (of mail sent) - Saves a copy of sent mail in your mailbox.
+  Author (always shown after text) - Always shows the author after an article.
+  Date (always absolute in text header) - Always shows the full date.
+  (Allow) beeps - Allows the terminal bell (BEL).
+  Clear (screen before textdisplay) - Clears the screen before each article.
+  Header (when reading e-mail/Usenet/FTN) - Shows raw header fields.
+  Compatibility (mode for special clients) - Compatibility mode for older clients.
+  Bell (with presence messages) - Beeps when users log in or out.
+  Old (who-list sort order) - Shows users logged in longest first.
+  ANSI colors - Displays some elements using ANSI colors.
+  Alternate (login screen) - Uses the alternate login screen.
+  Rookie mode - Shows beginner tips and adapted help.
+  (Always start in) Mailbox - Starts each session in your mailbox.

--- a/etc/help.eng/list_says
+++ b/etc/help.eng/list_says
@@ -1,0 +1,6 @@
+Arguments:
+  (<Number>)
+
+Description:
+  Displays previously sent and received say messages. If no number is
+  given, the 10 most recent messages are shown.

--- a/etc/help.eng/list_yells
+++ b/etc/help.eng/list_yells
@@ -1,0 +1,6 @@
+Arguments:
+  (<Number>)
+
+Description:
+  Displays previous global messages, such as yell, I and my messages.
+  If no number is given, the 10 most recent messages are shown.

--- a/etc/help.eng/mod_pinfo
+++ b/etc/help.eng/mod_pinfo
@@ -1,0 +1,8 @@
+Arguments:
+  None
+
+Description:
+  Lets you change your personal information, currently your email
+  address, website and location.
+
+  You will be asked to confirm the information before it is saved.

--- a/etc/help.eng/read_last_text
+++ b/etc/help.eng/read_last_text
@@ -1,0 +1,8 @@
+Arguments:
+  None
+
+Description:
+  Displays the latest text in your current reading of new texts.
+
+  This can for example be used to return to where you were after
+  temporarily reading another text.

--- a/etc/help.eng/survey_result
+++ b/etc/help.eng/survey_result
@@ -1,0 +1,13 @@
+Arguments:
+  <Survey number>
+
+Description:
+  Displays the complete result, or raw data, from a survey that has
+  already been reported.
+
+  This can for example be used to compare answers to several questions
+  and look for relationships between them.
+
+Please note:
+  The result cannot be displayed before the survey's reporting time has
+  passed.

--- a/etc/help.swe/bbslink
+++ b/etc/help.swe/bbslink
@@ -1,0 +1,25 @@
+Argument:
+  (<Spel>)
+
+Beskrivning:
+  Detta kommando startar onlinespel via den InterBBS-liknande tj{nsten
+  BBSLink.net, en plattform som i skrivande stund anv{nds av drygt 140
+  aktiva BBS:er. Om kommandot ges utan argument visas en lista |ver alla
+  tillg{ngliga spel.
+
+Observera:
+  Denna funktion kr{ver en hel del konfiguration fr}n SysOps sida.
+  En bra b|rjan {r att l{sa f|ljande dokumentation:
+
+  https://github.com/loppanloppis/sklaffkom-dev/wiki/BBSLink
+
+Bakgrund:
+  L}t oss vara {rliga - oavsett hur bra Unix {r, n{r det g{ller
+  speld|rrar i BBS-v{rlden {r DOS fortfarande kung. Vi kan naturligtvis
+  anv{nda dosemu f|r detta {ndam}l och anropa l{mpliga DOS-spel som
+  externa kommandon fr}n v}r BBS, men sannolikt skulle det i dessa tider
+  vara sv}rt att sammanf|ra mer {n en handfull spelare.
+
+  Med BBSLink kan vi ist{llet spela tillsammans med anv{ndare p} |ver
+  100 andra system fr}n hela v{rlden. Det kunde man inte f|rest{lla sig
+  1993, eller hur? ;)

--- a/etc/help.swe/change_comc
+++ b/etc/help.swe/change_comc
@@ -1,0 +1,27 @@
+Argument:
+  (<M|te>)
+
+Beskrivning:
+  Med detta kommando kan skaparen av ett m|te ange ett annat m|te som
+  kommentarsm|te. Ett kommentarsm|te kan anv{ndas f|r att placera
+  kommentarer till texter i ett annat m|te, till exempel om man vill
+  h}lla information och efterf|ljande diskussion }tskilda.
+
+  Om inget argument anges {ndras inst{llningen f|r det m|te du befinner
+  dig i. Om ett m|te anges som argument g{ller {ndringen detta m|te.
+  Du f}r d{refter ange vilket befintligt m|te som ska anv{ndas som
+  kommentarsm|te.
+
+Observera:
+  Endast den som skapade m|tet kan {ndra dess kommentarsm|te.
+
+  Om m|tet sj{lvt anges som kommentarsm|te tas kopplingen till ett
+  separat kommentarsm|te bort.
+
+  Kommandot kan inte anv{ndas f|r brevl}dan.
+
+Exempel:
+  Om m|tet "SysOp informerar" ska anv{nda "Diskussion" som kommentarsm|te:
+
+    -> {ndra kommentarsm|te SysOp informerar
+    Nytt m|te: Diskussion

--- a/etc/help.swe/display_commented
+++ b/etc/help.swe/display_commented
@@ -1,0 +1,18 @@
+Argument:
+  Inga
+
+Beskrivning:
+  Visar den text som den senast l{sta texten {r en kommentar till.
+  Kommandot {r anv{ndbart n{r du hamnat mitt i en diskussion och vill
+  g} tillbaka och se vad det egentligen var som kommenterades.
+
+  Om den f|reg}ende texten i sin tur ocks} {r en kommentar kan du ge
+  kommandot igen. P} s} s{tt kan du steg f|r steg f|lja diskussionen
+  bak}t, {nda till den ursprungliga texten.
+
+  Kommandot kan {ven f|lja kommentarer mellan olika m|ten, f|rutsatt
+  att du har r{tt att l{sa m|tet.
+
+Observera:
+  Om den senast l{sta texten inte {r en kommentar finns det naturligtvis
+  ingen tidigare text att visa.

--- a/etc/help.swe/display_last
+++ b/etc/help.swe/display_last
@@ -1,2 +1,8 @@
+Argument:
+  Inga
+
 Beskrivning:
-  L{ser den senast l{sta texten igen.
+  Visar den text du senast tittade p} en g}ng till.
+
+  Detta g{ller {ven om du tillf{lligt har hoppat till en annan, {ldre
+  text.

--- a/etc/help.swe/from
+++ b/etc/help.swe/from
@@ -1,0 +1,9 @@
+Argument:
+  (<Plats>)
+
+Beskrivning:
+  Anger varifr}n du {r inloggad. Texten visas f|r andra anv{ndare i
+  Vilka-listan och i din anv{ndarstatus.
+
+  Om kommandot ges utan argument }terst{lls v{rdet till systemets
+  hostname.

--- a/etc/help.swe/jumpuser
+++ b/etc/help.swe/jumpuser
@@ -1,0 +1,9 @@
+Argument:
+  (<Anv{ndare>)
+
+Beskrivning:
+  Markerar alla ol{sta texter av en viss anv{ndare i aktuellt m|te som
+  l{sta.
+
+  Om inget anv{ndarnamn anges anv{nds f|rfattaren till den senast l{sta
+  texten.

--- a/etc/help.swe/list_flags
+++ b/etc/help.swe/list_flags
@@ -1,2 +1,31 @@
 Beskrivning:
   Listar dina flaggor och vad de {r satta till.
+
+  De fyra f|rsta flaggorna anger vilken teckenupps{ttning din terminal anv{nder:
+
+  UTF-8 (teckenupps{ttning) - F|r de flesta moderna terminaler.
+  IBM-PC (teckenupps{ttning) - IBM CP437, vanligt i DOS-terminaler.
+  ISO 8859-1 (teckenupps{ttning) - Latin-1, vanligt val f|r Amiga-terminaler.
+  Macintosh (teckenupps{ttning) - F|r {ldre Macintosh-terminaler.
+
+  \vriga flaggor styr SklaffKOMs beteende:
+
+  (Visa) n{rvaromeddelanden - Visar n{r anv{ndare loggar in eller ut.
+  (Till}t) skrik - Till}ter meddelanden som skickas till alla inloggade.
+  Sluta (f|resl}s n{r du {r ikapp) - F|resl}r Sluta n{r inget finns att l{sa.
+  (Till}t) s{g - Till}ter personliga meddelanden fr}n andra anv{ndare.
+  [rende{ndring (vid kommentar) - Till}ter nytt {rende n{r du kommenterar.
+  Mellanslag (ger vagnretur) - Mellanslag fungerar som Retur i prompten.
+  Kopia (av s{nda brev) - Sparar en kopia av skickade brev i brevl}dan.
+  F|rfattare (alltid efter text) - Visar alltid f|rfattaren efter texten.
+  Datum (alltid absolut i texthuvud) - Visar alltid fullst{ndigt datum.
+  (Till}t) pip - Till}ter terminalens ljudsignal (BEL).
+  Rensa (sk{rmen f|re varje text) - Rensar sk{rmen f|re varje text.
+  Header (vid l{sning av e-post/Usenet/FTN) - Visar r}a headerf{lt.
+  Kompatibilitet (f|r specialklienter) - Kompatibilitetsl{ge f|r {ldre klienter.
+  Bell (vid n{rvaromeddelanden) - L}ter in- och utloggningar pipa.
+  Gammal (vilkalistesortering) - Visar {ldst inloggade f|rst.
+  ANSI-f{rger - Visar vissa element med ANSI-f{rger.
+  Alternativ (startsk{rm) - Anv{nder den alternativa startsk{rmen.
+  (Jag {r en) rookie - Visar nyb|rjartips och anpassad hj{lp.
+  (B|rja alltid i) Brevl}dan - B|rjar varje session i din brevl}da.

--- a/etc/help.swe/list_says
+++ b/etc/help.swe/list_says
@@ -1,0 +1,6 @@
+Argument:
+  (<Antal>)
+
+Beskrivning:
+  Visar tidigare skickade och mottagna s{gmeddelanden. Om inget antal
+  anges visas de 10 senaste.

--- a/etc/help.swe/list_yells
+++ b/etc/help.swe/list_yells
@@ -1,0 +1,6 @@
+Argument:
+  (<Antal>)
+
+Beskrivning:
+  Visar tidigare globala meddelanden, till exempel skrik-, jag- och
+  mina-meddelanden. Om inget antal anges visas de 10 senaste.

--- a/etc/help.swe/mod_pinfo
+++ b/etc/help.swe/mod_pinfo
@@ -1,0 +1,8 @@
+Argument:
+  Inga
+
+Beskrivning:
+  L}ter dig {ndra dina personliga uppgifter, f|r n{rvarande e-postadress,
+  hemsida och ort.
+
+  Du f}r bekr{fta uppgifterna innan de sparas.

--- a/etc/help.swe/read_last_text
+++ b/etc/help.swe/read_last_text
@@ -1,0 +1,8 @@
+Argument:
+  Inga
+
+Beskrivning:
+  Visar den senaste texten i din p}g}ende l{sning av nya texter.
+
+  Kommandot kan till exempel anv{ndas f|r att komma tillbaka till d{r
+  du var efter att tillf{lligt ha l{st en annan text.

--- a/etc/help.swe/survey_result
+++ b/etc/help.swe/survey_result
@@ -1,0 +1,12 @@
+Argument:
+  <Enk{tnummer>
+
+Beskrivning:
+  Visar det fullst{ndiga resultatet, r}datan, fr}n en enk{t som redan
+  har redovisats.
+
+  Detta kan till exempel anv{ndas f|r att j{mf|ra svaren p} flera
+  fr}gor och se samband mellan dem.
+
+Observera:
+  Resultatet kan inte visas innan enk{tens redovisningstid har passerat.

--- a/etc/parse.eng
+++ b/etc/parse.eng
@@ -98,6 +98,7 @@ Unpraise:cmd_unlike:Unpraise a text you have praised
 Unsubscribe (to):cmd_unsubscribe:Unsubscribe to a conference
 Upload (file):cmd_upload:Upload a file to current conference
 Version:cmd_version:Show current SklaffKOM version
+Wall:cmd_wall:Show the InterBBS-wall
 Where (am I):cmd_where:Show current conference
 Who (is online):cmd_who:Show logged in users
 (Show) entire (text):cmd_whole_text:Show text with absolute date

--- a/etc/parse.swe
+++ b/etc/parse.swe
@@ -27,7 +27,7 @@ G} (till m|te):cmd_change_conf:G} till ett annat m|te {n det nuvarande
 (Visa) hela (texten):cmd_whole_text:Visar texten med absolut datum
 (Visa) hj{lp:cmd_long_help:Visa utf|rlig hj{lp om s{rskilt kommando
 Hoppa (|ver kommentars-) tr{d:cmd_jump_tree:Hoppa |ver alla texter i tr{det
-Hoppa anv{ndare:cmd_jumpuser:Hoppa |ver alla texter skrivan av en anv{ndare
+Hoppa anv{ndare:cmd_jumpuser:Hoppa |ver alla texter skrivna av en anv{ndare
 Hoppa {rende:cmd_jumpsub:Hoppa |ver alla texter med ett visst {rende
 Hoppa |ver (alla kommentarer):cmd_jump_over:Hoppa |ver alla ol{sta kommentarer
 Hylla (text):cmd_like:Hyllar en text

--- a/etc/parse.swe
+++ b/etc/parse.swe
@@ -94,6 +94,7 @@ Var (befinner jag mig):cmd_where:Visa aktuellt m|te
 Version:cmd_version:Visa aktuell SklaffKOM-version
 Vilka ({r inloggade):cmd_who:Se vilka som k|r SklaffKOM just nu
 Visa licens:cmd_licens:Visa licensfilen f|r SklaffKOM
+V{ggen:cmd_wall:Visar InterBBS-v{ggen
 #]terse (text):cmd_read_text:Synonymt med 'L{sa (text)'
 ]terse kommenterad (text):cmd_display_commented:Synonymt med 'L{sa kommenterad (text)'
 ]terse senaste (text):cmd_read_last_text:Synonymt med 'L{sa senaste (text)'

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -2006,6 +2006,11 @@ find_ftn_conf(const char *name, struct ftn_conf_info *out_ce)
     FILE *fp;
     LONG_LINE line;
     struct ftn_conf_info ce;
+    struct ftn_conf_info tag_match;
+    size_t tag_matches;
+
+    if (name == NULL || *name == '\0' || out_ce == NULL)
+        return -1;
 
     printf("Checking the SklaffKOM CONF_FILE: %s... ", CONF_FILE);
     fflush(stdout);
@@ -2021,6 +2026,12 @@ find_ftn_conf(const char *name, struct ftn_conf_info *out_ce)
     printf("Checking conference: %s... ", name);
     fflush(stdout);
 
+    /*
+     * Preserve the old behaviour first: an exact SklaffKOM conference
+     * name always wins over an FTN echotag.
+     *
+     * modified on 2026-08-15, PL
+     */
     while (fgets(line, sizeof(line), fp) != NULL) {
         if (parse_conf_line(line, &ce) != 0)
             continue;
@@ -2033,8 +2044,63 @@ find_ftn_conf(const char *name, struct ftn_conf_info *out_ce)
         }
     }
 
+    /*
+     * New conference layout: the FTN tag is stored in
+     *   SKLAFF_DB/<confnum>/ftnconf
+     * rather than being required to equal the SklaffKOM conference name.
+     * If no conference name matched, resolve the supplied value as an
+     * echotag.  Tags are case-insensitive in FTN configuration.
+     *
+     * modified on 2026-08-15, PL
+     */
+    rewind(fp);
+    tag_matches = 0;
+    memset(&tag_match, 0, sizeof(tag_match));
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        struct meeting_ftn_config meeting;
+        int has_ftnconf;
+
+        if (parse_conf_line(line, &ce) != 0)
+            continue;
+
+        if (!conf_is_ftn(ce.type))
+            continue;
+
+        has_ftnconf = 0;
+        if (load_meeting_ftnconf(&ce, &meeting, &has_ftnconf) != 0) {
+            fclose(fp);
+            return -1;
+        }
+
+        if (!has_ftnconf)
+            continue;
+
+        if (strcasecmp(name, meeting.tag) != 0)
+            continue;
+
+        tag_match = ce;
+        tag_matches++;
+    }
+
     fclose(fp);
-    fprintf(stderr, "\n[ERROR] Conference '%s' not found in %s\n", name, CONF_FILE);
+
+    if (tag_matches == 1) {
+        *out_ce = tag_match;
+        printf("OK! (%s, echotag)\n", tag_match.name);
+        return 0;
+    }
+
+    if (tag_matches > 1) {
+        fprintf(stderr,
+            "\n[ERROR] Echotag '%s' matches more than one FTN conference\n",
+            name);
+        return -1;
+    }
+
+    fprintf(stderr,
+        "\n[ERROR] Conference or FTN echotag '%s' not found in %s\n",
+        name, CONF_FILE);
     return -1;
 }
 

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -3095,7 +3095,7 @@ export_test_ftn(const char *area)
 
     printf("OK!\n");
 
-    if (ce.type != FTN_CONF) {
+    if (!conf_is_ftn(ce.type)) {
         fprintf(stderr,
             "[ERROR] Conference '%s' exists, but is not FTN_CONF "
             "(type=%d)\n", area, ce.type);
@@ -3266,7 +3266,7 @@ export_one_ftn_loaded(const struct ftn_conf_info *source_ce, long textnum)
     printf("ftntoss export-one starting\n");
     printf("===========================\n\n");
 
-    if (ce.type != FTN_CONF) {
+    if (!conf_is_ftn(ce.type)) {
         fprintf(stderr,
             "[ERROR] Conference '%s' exists, but is not FTN_CONF "
             "(type=%d)\n", ce.name, ce.type);
@@ -3428,7 +3428,7 @@ import_one_ftn(const char *area, const char *filename)
     if (find_ftn_conf(area, &ce) != 0)
         goto cleanup;
 
-    if (ce.type != FTN_CONF) {
+    if (!conf_is_ftn(ce.type)) {
         fprintf(stderr, "[ERROR] Conference '%s' exists, but is not FTN_CONF (type=%d)\n",
             ce.name, ce.type);
         goto cleanup;
@@ -3625,7 +3625,7 @@ import_all_ftn(const char *area, int include_unsafe)
     if (find_ftn_conf(area, &ce) != 0)
         goto cleanup;
 
-    if (ce.type != FTN_CONF) {
+    if (!conf_is_ftn(ce.type)) {
         fprintf(stderr, "[ERROR] Conference '%s' exists, but is not FTN_CONF (type=%d)\n",
             ce.name, ce.type);
         goto cleanup;
@@ -3867,7 +3867,7 @@ import_all_areas_ftn(int include_unsafe)
         if (parse_conf_line(line, &ce) != 0)
             continue;
 
-        if (ce.type != FTN_CONF)
+        if (!conf_is_ftn(ce.type))
             continue;
 
         areas++;
@@ -3938,7 +3938,7 @@ diagnose_ftn(const char *area, int include_unsafe)
     if (find_ftn_conf(area, &ce) != 0)
         goto cleanup;
 
-    if (ce.type != FTN_CONF) {
+    if (!conf_is_ftn(ce.type)) {
         fprintf(stderr, "[ERROR] Conference '%s' exists, but is not FTN_CONF (type=%d)\n",
             ce.name, ce.type);
         goto cleanup;
@@ -4082,7 +4082,7 @@ dump_one_import(const char *area, const struct ftn_conf_info *ce,
     if (area == NULL || ce == NULL || filename == NULL)
         goto cleanup;
 
-    if (ce->type != FTN_CONF) {
+    if (!conf_is_ftn(ce->type)) {
         fprintf(stderr, "[ERROR] Conference '%s' exists, but is not FTN_CONF (type=%d)\n",
             ce->name, ce->type);
         goto cleanup;
@@ -4100,7 +4100,7 @@ dump_one_import(const char *area, const struct ftn_conf_info *ce,
     printf("Conf name:   %s\n", ce->name);
     printf("Conf num:    %d\n", ce->num);
     printf("Conf type:   %d", ce->type);
-    if (ce->type == FTN_CONF)
+    if (conf_is_ftn(ce->type))
         printf(" (FTN_CONF)");
     printf("\n");
     printf("Last text:   %ld\n", ce->last_text);
@@ -4508,7 +4508,7 @@ scan_ftn_area(const char *area, const struct ftn_conf_info *ce)
     if (area == NULL || ce == NULL)
         return -1;
 
-    if (ce->type != FTN_CONF) {
+    if (!conf_is_ftn(ce->type)) {
         fprintf(stderr, "[ERROR] Conference '%s' exists, but is not FTN_CONF (type=%d)\n",
             ce->name, ce->type);
         ftn_config_free(&config);
@@ -4527,7 +4527,7 @@ scan_ftn_area(const char *area, const struct ftn_conf_info *ce)
     printf("Conf name:   %s\n", ce->name);
     printf("Conf num:    %d\n", ce->num);
     printf("Conf type:   %d", ce->type);
-    if (ce->type == FTN_CONF)
+    if (conf_is_ftn(ce->type))
         printf(" (FTN_CONF)");
     printf("\n");
     printf("Last text:   %ld\n", ce->last_text);

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -116,6 +116,10 @@ struct export_netmail_job_args {
     const char *jobfile;
 }; /* modified on 2026-07-11, PL */
 
+struct export_ibol_job_args {
+    const char *jobfile;
+}; /* modified on 2026-08-13, PL */
+
 struct netmail_job {
     int fromuid;
     char toname[128];
@@ -126,6 +130,13 @@ struct netmail_job {
     char *body;
 }; /* modified on 2026-07-11, PL */
 
+struct ibol_job {
+    int fromuid;
+    char author[128];
+    long created;
+    char text[IBOL_ONELINER_MAX + 1];
+}; /* modified on 2026-08-13, PL */
+
 struct netmail_destination {
     struct ftn_address address;
     char domain[FTN_DOMAIN_LEN];
@@ -135,6 +146,9 @@ struct netmail_destination {
 static int run_export_netmail_job_locked(void *arg); /* modified on 2026-07-11, PL */
 static int export_netmail_job(const char *jobfile); /* modified on 2026-07-11, PL */
 static int read_netmail_job(const char *path, struct netmail_job *job); /* modified on 2026-07-11, PL */
+static int run_export_ibol_job_locked(void *arg); /* modified on 2026-08-13, PL */
+static int export_ibol_job(const char *jobfile); /* modified on 2026-08-13, PL */
+static int read_ibol_job(const char *path, struct ibol_job *job); /* modified on 2026-08-13, PL */
 static void free_netmail_job(struct netmail_job *job); /* modified on 2026-07-11, PL */
 static int parse_ftn_addr_5d(const char *addr,
     struct netmail_destination *destination); /* modified on 2026-07-16, PL */
@@ -181,6 +195,10 @@ static int load_echomail_area(const char *fallback_tag,
     const struct ftn_conf_info *ce, struct ftn_config *config,
     const struct ftn_area **out_area,
     const struct ftn_link **out_feed); /* modified on 2026-07-15, PL */
+static int load_echomail_area_by_identity(const char *domain,
+    const char *tag, struct ftn_config *config,
+    const struct ftn_area **out_area,
+    const struct ftn_link **out_feed); /* modified on 2026-08-13, PL */
 
 static int find_ftn_conf(const char *name, struct ftn_conf_info *out_ce);
 static int find_ftn_conf_num(int confnum, struct ftn_conf_info *out_ce); /* modified on 2026-08-11, PL */
@@ -1626,6 +1644,226 @@ export_netmail_job(const char *jobfile)
 
 cleanup:
     free_netmail_job(&job);
+    ftn_config_free(&config);
+    return rc;
+}
+
+/*
+ * read_ibol_job - read one queued InterBBS Oneliner job
+ * args: queue path, output job
+ * ret: success (0) or error (-1)
+ *
+ * Queue text is SklaffKOM SF7.  Conversion to UTF-8 happens only at the
+ * FTN export boundary.
+ *
+ * modified on 2026-08-13, PL
+ */
+static int
+read_ibol_job(const char *path, struct ibol_job *job)
+{
+    FILE *fp;
+    char line[1024];
+    int in_body;
+    int seen_type;
+    int seen_text;
+
+    if (path == NULL || job == NULL)
+        return -1;
+
+    memset(job, 0, sizeof(*job));
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        perror(path);
+        return -1;
+    }
+
+    in_body = 0;
+    seen_type = 0;
+    seen_text = 0;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        strip_eol(line);
+
+        if (!in_body) {
+            char *v;
+
+            if (line[0] == '\0') {
+                in_body = 1;
+                continue;
+            }
+
+            if (strncmp(line, "TYPE:", 5) == 0) {
+                v = line + 5;
+                while (*v == ' ' || *v == '\t')
+                    v++;
+
+                if (strcmp(v, "IBOL") != 0) {
+                    fclose(fp);
+                    return -1;
+                }
+                seen_type = 1;
+            } else if (strncmp(line, "FROMUID:", 8) == 0) {
+                v = line + 8;
+                while (*v == ' ' || *v == '\t')
+                    v++;
+                job->fromuid = atoi(v);
+            } else if (strncmp(line, "AUTHOR:", 7) == 0) {
+                v = line + 7;
+                while (*v == ' ' || *v == '\t')
+                    v++;
+                strlcpy(job->author, v, sizeof(job->author));
+            } else if (strncmp(line, "CREATED:", 8) == 0) {
+                v = line + 8;
+                while (*v == ' ' || *v == '\t')
+                    v++;
+                job->created = atol(v);
+            }
+
+            continue;
+        }
+
+        /*
+         * A SklaffKOM IBOL post is deliberately one physical line.
+         * Ignore trailing blank lines from the queue file, but reject a
+         * second non-empty line rather than silently creating a multi-liner.
+         */
+        if (line[0] == '\0')
+            continue;
+
+        if (seen_text) {
+            fclose(fp);
+            return -1;
+        }
+
+        if (strlen(line) > IBOL_ONELINER_MAX) {
+            fclose(fp);
+            return -1;
+        }
+
+        strlcpy(job->text, line, sizeof(job->text));
+        seen_text = 1;
+    }
+
+    fclose(fp);
+
+    if (!seen_type || job->fromuid <= 0 || job->author[0] == '\0' ||
+        job->created <= 0 || !seen_text || job->text[0] == '\0')
+        return -1;
+
+    return 0;
+}
+
+/*
+ * export_ibol_job - turn one queued SklaffKOM oneliner into FSX_DAT .MSG
+ * args: queue job path
+ * ret: success (0) or error (-1)
+ *
+ * The target spool path, local AKA and feed are resolved from
+ * crashmail.prefs using IBOL_FTN_AREA@IBOL_FTN_DOMAIN.  No spool path or
+ * node address is hard-coded here.
+ *
+ * modified on 2026-08-13, PL
+ */
+static int
+export_ibol_job(const char *jobfile)
+{
+    struct ibol_job job;
+    struct ftn_config config;
+    const struct ftn_area *ftn_area;
+    const struct ftn_link *feed;
+    char path[PATH_MAX];
+    char msgid[128];
+    char aka[64];
+    char feedaddr[64];
+    char body[1024];
+    char *utf8_author;
+    char *utf8_source;
+    char *utf8_text;
+    long msgnum;
+    unsigned long serial;
+    int rc;
+
+    if (jobfile == NULL)
+        return -1;
+
+    memset(&job, 0, sizeof(job));
+    ftn_config_init(&config);
+    ftn_area = NULL;
+    feed = NULL;
+    utf8_author = NULL;
+    utf8_source = NULL;
+    utf8_text = NULL;
+    rc = -1;
+
+    if (read_ibol_job(jobfile, &job) != 0) {
+        fprintf(stderr, "[ERROR] Could not read IBOL job: %s\n", jobfile);
+        goto cleanup;
+    }
+
+    if (load_echomail_area_by_identity(IBOL_FTN_DOMAIN, IBOL_FTN_AREA,
+            &config, &ftn_area, &feed) != 0)
+        goto cleanup;
+
+    /*
+     * Interactive SklaffKOM input and user names are stored as SF7.
+     * IBOL .MSG files advertise UTF-8, so convert both at the boundary.
+     */
+    utf8_author = sf7_to_utf8_dup(job.author);
+    utf8_source = sf7_to_utf8_dup(SKLAFF_ID);
+    utf8_text = sf7_to_utf8_dup(job.text);
+
+    if (utf8_author == NULL || utf8_source == NULL || utf8_text == NULL) {
+        fprintf(stderr,
+            "[ERROR] Could not convert outgoing IBOL text from SF7 to UTF-8\n");
+        goto cleanup;
+    }
+
+    if (next_msg_path(ftn_area->path, path, sizeof(path), &msgnum) != 0)
+        goto cleanup;
+
+    serial = (((unsigned long)job.created & 0xffffUL) << 16) |
+        ((unsigned long)msgnum & 0xffffUL);
+    make_ftn_msgid_for_aka(msgid, sizeof(msgid), &ftn_area->aka, serial);
+
+    if (snprintf(body, sizeof(body),
+            "Author: %s\n"
+            "Source: %s\n"
+            "\n"
+            "Oneliner: %s",
+            utf8_author, utf8_source, utf8_text) >= (int)sizeof(body)) {
+        fprintf(stderr, "[ERROR] IBOL message body too long\n");
+        goto cleanup;
+    }
+
+    ftn_address_format(&ftn_area->aka, aka, sizeof(aka));
+    ftn_address_format(&feed->address, feedaddr, sizeof(feedaddr));
+
+    printf("IBOL export setup\n");
+    printf("-----------------\n");
+    printf("Domain:     %s\n", ftn_area->domain);
+    printf("Area:       %s\n", ftn_area->tag);
+    printf("AKA:        %s\n", aka);
+    printf("Feed:       %s\n", feedaddr);
+    printf("Spool:      %s\n", ftn_area->path);
+    printf("Msg no:     %ld\n", msgnum);
+    printf("Author:     %s\n", utf8_author);
+    printf("Source:     %s\n", utf8_source);
+    printf("MSGID:      %s\n", msgid);
+    printf("Output:     %s\n\n", path);
+
+    rc = write_fido_msg_out(path, ftn_area, feed,
+        utf8_author,
+        "IBBS1LINE",
+        "InterBBS Oneliner",
+        body,
+        NULL,
+        msgid);
+
+cleanup:
+    free(utf8_author);
+    free(utf8_source);
+    free(utf8_text);
     ftn_config_free(&config);
     return rc;
 }
@@ -5081,6 +5319,17 @@ run_export_netmail_job_locked(void *arg)
 }
 
 static int
+run_export_ibol_job_locked(void *arg)
+{
+    struct export_ibol_job_args *a = arg;
+
+    if (a == NULL || a->jobfile == NULL)
+        return -1;
+
+    return export_ibol_job(a->jobfile);
+}
+
+static int
 load_meeting_ftnconf(const struct ftn_conf_info *ce,
     struct meeting_ftn_config *meeting, int *out_found)
 {
@@ -5453,6 +5702,133 @@ load_echomail_area(const char *fallback_tag,
     return 0;
 }
 
+/*
+ * load_echomail_area_by_identity - resolve a non-conference echomail target
+ * args: FTN domain, echo tag, loaded-config output, area output, feed output
+ * ret: success (0) or error (-1)
+ *
+ * IBOL lives in a data echo rather than a normal SklaffKOM conference.
+ * Resolve it directly from CrashMail configuration while keeping the same
+ * unique-feed rules as normal FTN conference export.
+ *
+ * modified on 2026-08-13, PL
+ */
+static int
+load_echomail_area_by_identity(const char *domain, const char *tag,
+    struct ftn_config *config, const struct ftn_area **out_area,
+    const struct ftn_link **out_feed)
+{
+    const struct ftn_area *found;
+    const struct ftn_link *feed;
+    char error[512];
+    size_t i;
+    size_t matches;
+    size_t primary_feeds;
+
+    if (domain == NULL || *domain == '\0' ||
+        tag == NULL || *tag == '\0' ||
+        config == NULL || out_area == NULL || out_feed == NULL)
+        return -1;
+
+    *out_area = NULL;
+    *out_feed = NULL;
+    found = NULL;
+    feed = NULL;
+    matches = 0;
+    primary_feeds = 0;
+
+    ftn_config_init(config);
+
+    if (ftn_config_load_crashmail(CRASHMAIL_PREFS_FILE, config,
+            error, sizeof(error)) != 0) {
+        fprintf(stderr, "[ERROR] ftntoss: %s\n", error);
+        return -1;
+    }
+
+    for (i = 0; i < config->area_count; i++) {
+        const struct ftn_area *candidate;
+
+        candidate = &config->areas[i];
+
+        if (candidate->type != FTN_AREA_ECHOMAIL)
+            continue;
+        if (strcasecmp(candidate->tag, tag) != 0)
+            continue;
+        if (strcasecmp(candidate->domain, domain) != 0)
+            continue;
+
+        found = candidate;
+        matches++;
+    }
+
+    if (matches == 0) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: echomail area %s@%s was not found in %s\n",
+            tag, domain, CRASHMAIL_PREFS_FILE);
+        ftn_config_free(config);
+        return -1;
+    }
+
+    if (matches > 1) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: more than one echomail area matches %s@%s "
+            "in %s\n",
+            tag, domain, CRASHMAIL_PREFS_FILE);
+        ftn_config_free(config);
+        return -1;
+    }
+
+    if (found->messagebase[0] == '\0' ||
+        strcasecmp(found->messagebase, "MSG") != 0) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: area '%s' uses unsupported messagebase '%s'; "
+            "only MSG is currently supported\n",
+            found->tag,
+            found->messagebase[0] ? found->messagebase : "(missing)");
+        ftn_config_free(config);
+        return -1;
+    }
+
+    if (found->path[0] == '\0') {
+        fprintf(stderr,
+            "[ERROR] ftntoss: area '%s' has no messagebase path in %s\n",
+            found->tag, CRASHMAIL_PREFS_FILE);
+        ftn_config_free(config);
+        return -1;
+    }
+
+    for (i = 0; i < found->link_count; i++) {
+        if (found->links[i].modifier != '%')
+            continue;
+
+        feed = &found->links[i];
+        primary_feeds++;
+    }
+
+    if (primary_feeds == 0 && found->link_count == 1)
+        feed = &found->links[0];
+
+    if (primary_feeds > 1) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: area '%s' has more than one %% feed in %s\n",
+            found->tag, CRASHMAIL_PREFS_FILE);
+        ftn_config_free(config);
+        return -1;
+    }
+
+    if (feed == NULL) {
+        fprintf(stderr,
+            "[ERROR] ftntoss: area '%s' has no unique CrashMail feed\n",
+            found->tag);
+        ftn_config_free(config);
+        return -1;
+    }
+
+    *out_area = found;
+    *out_feed = feed;
+    return 0;
+}
+
 static int
 dump_ftn_config_file(const char *path)
 {
@@ -5619,6 +5995,14 @@ main(int argc, char **argv)
         return run_with_lock(run_import_netmail_locked, &a) == 0 ? 0 : 1;
     }
 
+    if (argc == 3 && strcmp(argv[1], "--export-ibol-job") == 0) {
+        struct export_ibol_job_args a;
+
+        a.jobfile = argv[2];
+
+        return run_with_lock(run_export_ibol_job_locked, &a) == 0 ? 0 : 1;
+    }
+
     if (argc == 3 && strcmp(argv[1], "--export-netmail-job") == 0) {
         struct export_netmail_job_args a;
 
@@ -5641,6 +6025,7 @@ main(int argc, char **argv)
         fprintf(stderr, "       %s --export-one <FTN-area> <textnum>\n", argv[0]);
         fprintf(stderr, "       %s --export-one-conf <confnum> <textnum>\n", argv[0]);
         fprintf(stderr, "       %s --export-netmail-job <jobfile>\n", argv[0]);
+        fprintf(stderr, "       %s --export-ibol-job <jobfile>\n", argv[0]);
         fprintf(stderr, "       %s --import-netmail <crashmail.prefs>\n", argv[0]);
         fprintf(stderr, "       %s --dump-ftn-config\n", argv[0]);
         fprintf(stderr, "       %s --dump-ftn-config <crashmail.prefs>\n\n", argv[0]);

--- a/ftntoss.c
+++ b/ftntoss.c
@@ -2639,6 +2639,102 @@ strip_eol(char *s)
     }
 }
 
+/*
+ * load_user_signature - read ![sig] directly from user's sklaffrc
+ * args: user id
+ * ret: malloced signature or NULL if none
+ *
+ * modified on 2026-08-12, PL
+ */
+static char *
+load_user_signature(int uid)
+{
+    FILE *fp;
+    char path[PATH_MAX];
+    char line[4096];
+    char *sig;
+    size_t len;
+    size_t cap;
+    int in_sig;
+
+    if (uid <= 0)
+        return NULL;
+
+    if (snprintf(path, sizeof(path), "%s/%d%s",
+            USER_DB, uid, SKLAFFRC_FILE) >= (int)sizeof(path))
+        return NULL;
+
+    fp = fopen(path, "r");
+    if (fp == NULL)
+        return NULL;
+
+    sig = NULL;
+    len = 0;
+    cap = 0;
+    in_sig = 0;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        size_t line_len;
+
+        if (strncmp(line, "![", 2) == 0) {
+            char heading[4096];
+
+            strlcpy(heading, line, sizeof(heading));
+            strip_eol(heading);
+
+            if (in_sig)
+                break;
+
+            if (strcmp(heading, "![sig]") == 0)
+                in_sig = 1;
+
+            continue;
+        }
+
+        if (!in_sig)
+            continue;
+
+        line_len = strlen(line);
+
+        if (len + line_len + 1 > cap) {
+            char *new_sig;
+            size_t new_cap;
+
+            new_cap = cap ? cap * 2 : 4096;
+            while (new_cap < len + line_len + 1)
+                new_cap *= 2;
+
+            new_sig = realloc(sig, new_cap);
+            if (new_sig == NULL) {
+                free(sig);
+                fclose(fp);
+                return NULL;
+            }
+
+            sig = new_sig;
+            cap = new_cap;
+        }
+
+        memcpy(sig + len, line, line_len);
+        len += line_len;
+        sig[len] = '\0';
+    }
+
+    fclose(fp);
+
+    if (sig == NULL)
+        return NULL;
+
+    strip_eol(sig);
+
+    if (sig[0] == '\0') {
+        free(sig);
+        return NULL;
+    }
+
+    return sig;
+}
+
 static int
 ftntoss_get_sklaff_ids(uid_t *uid, gid_t *gid)
 {
@@ -3293,6 +3389,63 @@ export_one_ftn_loaded(const struct ftn_conf_info *source_ce, long textnum)
         fprintf(stderr,
             "[ERROR] Could not convert outgoing FTN text from SF7 to UTF-8\n");
         goto cleanup;
+    }
+
+    /*
+     * Add the user's SklaffKOM signature to outgoing FTN echomail.
+     * The signature is stored as SF7 and must therefore be converted
+     * to UTF-8 before being appended to the outgoing body.
+     *
+     * modified on 2026-08-12, PL
+     */
+    /*
+     * Add the user's SklaffKOM signature to outgoing FTN echomail.
+     *
+     * modified on 2026-08-12, PL
+     */
+    if (uid > 0) {
+        char *sig;
+        char *utf8_sig;
+
+        sig = load_user_signature((int)uid);
+        if (sig != NULL) {
+            char *new_body;
+            size_t body_len;
+            size_t sig_len;
+
+            utf8_sig = sf7_to_utf8_dup(sig);
+            free(sig);
+
+            if (utf8_sig == NULL) {
+                fprintf(stderr,
+                    "[ERROR] Could not convert outgoing FTN "
+                    "signature from SF7 to UTF-8\n");
+                goto cleanup;
+            }
+
+            strip_eol(utf8_body);
+            strip_eol(utf8_sig);
+
+            body_len = strlen(utf8_body);
+            sig_len = strlen(utf8_sig);
+
+            new_body = realloc(utf8_body,
+                body_len + sig_len + 3);
+            if (new_body == NULL) {
+                free(utf8_sig);
+                fprintf(stderr,
+                    "[ERROR] Could not allocate outgoing "
+                    "FTN message with signature\n");
+                goto cleanup;
+            }
+
+            utf8_body = new_body;
+            memcpy(utf8_body + body_len, "\n\n", 2);
+            memcpy(utf8_body + body_len + 2,
+                utf8_sig, sig_len + 1);
+
+            free(utf8_sig);
+        }
     }
 
     make_skom_from_name(uid, from, sizeof(from));

--- a/iboldb.c
+++ b/iboldb.c
@@ -1,0 +1,466 @@
+/* iboldb.c */
+
+#define _POSIX_C_SOURCE 200809L
+
+/*
+ *   SklaffKOM, a simple conference system for UNIX.
+ *
+ *   Copyright (C) 1993-1994  Torbjörn Bååth, Peter Forsberg, Peter Lindberg,
+ *                            Odd Petersson, Carl Sundbom
+ *   Copyright (C) 2026       Peter London
+ *
+ *   Program dedicated to the memory of Staffan Bergström.
+ *
+ *   For questions about this program, mail sklaff@sklaffkom.se
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ */
+
+#include "iboldb.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void set_error(char *error, size_t errorsz, const char *fmt, ...);
+static int write_escaped(FILE *fp, const char *s);
+static int append_decoded(char *dst, size_t dstsz, size_t *used, char ch);
+static int parse_decoded_field(const char **pp, int final_field,
+    char *dst, size_t dstsz, char *error, size_t errorsz);
+static int sync_file(FILE *fp);
+
+void
+ibol_record_init(struct ibol_record *record)
+{
+    if (record != NULL)
+        memset(record, 0, sizeof(*record));
+}
+
+static void
+set_error(char *error, size_t errorsz, const char *fmt, ...)
+{
+    va_list ap;
+
+    if (error == NULL || errorsz == 0)
+        return;
+
+    va_start(ap, fmt);
+    vsnprintf(error, errorsz, fmt, ap);
+    va_end(ap);
+}
+
+static int
+write_escaped(FILE *fp, const char *s)
+{
+    const unsigned char *p;
+
+    if (fp == NULL)
+        return -1;
+    if (s == NULL)
+        s = "";
+
+    for (p = (const unsigned char *)s; *p != '\0'; p++) {
+        switch (*p) {
+        case '\\':
+            if (fputs("\\\\", fp) == EOF)
+                return -1;
+            break;
+        case ':':
+            if (fputs("\\:", fp) == EOF)
+                return -1;
+            break;
+        case '\n':
+            if (fputs("\\n", fp) == EOF)
+                return -1;
+            break;
+        case '\r':
+            if (fputs("\\r", fp) == EOF)
+                return -1;
+            break;
+        case '\t':
+            if (fputs("\\t", fp) == EOF)
+                return -1;
+            break;
+        default:
+            if (fputc(*p, fp) == EOF)
+                return -1;
+            break;
+        }
+    }
+
+    return 0;
+}
+
+int
+ibol_db_write_record(FILE *fp, const struct ibol_record *record)
+{
+    if (fp == NULL || record == NULL)
+        return -1;
+
+    if (fprintf(fp, "%lld:", record->timestamp) < 0)
+        return -1;
+    if (write_escaped(fp, record->msgid) != 0 || fputc(':', fp) == EOF)
+        return -1;
+    if (write_escaped(fp, record->author) != 0 || fputc(':', fp) == EOF)
+        return -1;
+    if (write_escaped(fp, record->source) != 0 || fputc(':', fp) == EOF)
+        return -1;
+    if (write_escaped(fp, record->text) != 0 || fputc('\n', fp) == EOF)
+        return -1;
+
+    return ferror(fp) ? -1 : 0;
+}
+
+static int
+append_decoded(char *dst, size_t dstsz, size_t *used, char ch)
+{
+    if (*used + 1 >= dstsz)
+        return -1;
+    dst[(*used)++] = ch;
+    dst[*used] = '\0';
+    return 0;
+}
+
+static int
+parse_decoded_field(const char **pp, int final_field,
+    char *dst, size_t dstsz, char *error, size_t errorsz)
+{
+    const char *p;
+    size_t used;
+
+    if (pp == NULL || *pp == NULL || dst == NULL || dstsz == 0)
+        return -1;
+
+    p = *pp;
+    used = 0;
+    dst[0] = '\0';
+
+    while (*p != '\0' && *p != '\n' && *p != '\r') {
+        char ch;
+
+        if (!final_field && *p == ':') {
+            p++;
+            *pp = p;
+            return 0;
+        }
+
+        if (*p != '\\') {
+            if (append_decoded(dst, dstsz, &used, *p++) != 0) {
+                set_error(error, errorsz, "cache field is too long");
+                return -1;
+            }
+            continue;
+        }
+
+        p++;
+        if (*p == '\0' || *p == '\n' || *p == '\r') {
+            set_error(error, errorsz, "dangling escape at end of cache field");
+            return -1;
+        }
+
+        switch (*p) {
+        case 'n': ch = '\n'; break;
+        case 'r': ch = '\r'; break;
+        case 't': ch = '\t'; break;
+        case ':': ch = ':'; break;
+        case '\\': ch = '\\'; break;
+        default:
+            /* Be conservative with future/unknown escapes: preserve them. */
+            if (append_decoded(dst, dstsz, &used, '\\') != 0) {
+                set_error(error, errorsz, "cache field is too long");
+                return -1;
+            }
+            ch = *p;
+            break;
+        }
+        p++;
+
+        if (append_decoded(dst, dstsz, &used, ch) != 0) {
+            set_error(error, errorsz, "cache field is too long");
+            return -1;
+        }
+    }
+
+    if (!final_field) {
+        set_error(error, errorsz, "cache line has too few fields");
+        return -1;
+    }
+
+    *pp = p;
+    return 0;
+}
+
+int
+ibol_db_parse_line(const char *line, struct ibol_record *record,
+    char *error, size_t errorsz)
+{
+    const char *p;
+    char stamp[64];
+    char *end;
+    long long timestamp;
+
+    if (line == NULL || record == NULL) {
+        set_error(error, errorsz, "line or record is NULL");
+        return -1;
+    }
+
+    ibol_record_init(record);
+    p = line;
+
+    if (parse_decoded_field(&p, 0, stamp, sizeof(stamp), error, errorsz) != 0)
+        return -1;
+
+    errno = 0;
+    timestamp = strtoll(stamp, &end, 10);
+    if (errno != 0 || end == stamp || *end != '\0' || timestamp < 0) {
+        set_error(error, errorsz, "invalid unix timestamp '%s'", stamp);
+        return -1;
+    }
+    record->timestamp = timestamp;
+
+    if (parse_decoded_field(&p, 0, record->msgid, sizeof(record->msgid),
+            error, errorsz) != 0 ||
+        parse_decoded_field(&p, 0, record->author, sizeof(record->author),
+            error, errorsz) != 0 ||
+        parse_decoded_field(&p, 0, record->source, sizeof(record->source),
+            error, errorsz) != 0 ||
+        parse_decoded_field(&p, 1, record->text, sizeof(record->text),
+            error, errorsz) != 0)
+        return -1;
+
+    if (record->msgid[0] == '\0') {
+        set_error(error, errorsz, "cache record has empty MSGID");
+        return -1;
+    }
+
+    if (error != NULL && errorsz > 0)
+        error[0] = '\0';
+    return 0;
+}
+
+static int
+sync_file(FILE *fp)
+{
+    if (fflush(fp) != 0)
+        return -1;
+    if (fsync(fileno(fp)) != 0)
+        return -1;
+    return 0;
+}
+
+int
+ibol_db_append(const char *path, const struct ibol_record *record)
+{
+    FILE *fp;
+    int rc;
+
+    if (path == NULL || record == NULL)
+        return -1;
+
+    fp = fopen(path, "a");
+    if (fp == NULL)
+        return -1;
+
+    rc = ibol_db_write_record(fp, record);
+    if (rc == 0)
+        rc = sync_file(fp);
+    if (fclose(fp) != 0)
+        rc = -1;
+
+    return rc;
+}
+
+static int
+read_previous_physical_line(FILE *fp, long *scanp, char **line_out,
+    char *error, size_t errorsz)
+{
+    long scan;
+    long line_end;
+    long line_start;
+    long len;
+    char *line;
+
+    if (fp == NULL || scanp == NULL || line_out == NULL)
+        return -1;
+
+    *line_out = NULL;
+    scan = *scanp;
+
+    /* Ignore CR/LF between physical records and at EOF. */
+    while (scan > 0) {
+        int ch;
+
+        if (fseek(fp, scan - 1, SEEK_SET) != 0) {
+            set_error(error, errorsz, "cannot seek cache");
+            return -1;
+        }
+        ch = fgetc(fp);
+        if (ch != '\n' && ch != '\r')
+            break;
+        scan--;
+    }
+
+    if (scan == 0) {
+        *scanp = 0;
+        return 0;
+    }
+
+    line_end = scan;
+    line_start = scan;
+    while (line_start > 0) {
+        int ch;
+
+        if (fseek(fp, line_start - 1, SEEK_SET) != 0) {
+            set_error(error, errorsz, "cannot seek cache");
+            return -1;
+        }
+        ch = fgetc(fp);
+        if (ch == '\n' || ch == '\r')
+            break;
+        line_start--;
+    }
+
+    len = line_end - line_start;
+    *scanp = line_start;
+
+    if (len <= 0)
+        return 0;
+
+    line = malloc((size_t)len + 1);
+    if (line == NULL) {
+        set_error(error, errorsz, "out of memory");
+        return -1;
+    }
+
+    if (fseek(fp, line_start, SEEK_SET) != 0 ||
+        fread(line, 1, (size_t)len, fp) != (size_t)len) {
+        free(line);
+        set_error(error, errorsz, "cannot read cache");
+        return -1;
+    }
+
+    line[len] = '\0';
+    *line_out = line;
+    return 1;
+}
+
+int
+ibol_db_read_recent(const char *path, struct ibol_record *records,
+    size_t max_records, size_t *count_out, char *error, size_t errorsz)
+{
+    FILE *fp;
+    long scan;
+    long end;
+    size_t found;
+
+    if (count_out != NULL)
+        *count_out = 0;
+
+    if (path == NULL || count_out == NULL ||
+        (max_records > 0 && records == NULL)) {
+        set_error(error, errorsz, "invalid argument to ibol_db_read_recent");
+        return -1;
+    }
+
+    if (max_records == 0) {
+        if (error != NULL && errorsz > 0)
+            error[0] = '\0';
+        return 0;
+    }
+
+    fp = fopen(path, "rb");
+    if (fp == NULL) {
+        set_error(error, errorsz, "cannot open '%s': %s", path,
+            strerror(errno));
+        return -1;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0 || (end = ftell(fp)) < 0) {
+        set_error(error, errorsz, "cannot seek '%s'", path);
+        fclose(fp);
+        return -1;
+    }
+
+    scan = end;
+    found = 0;
+
+    while (scan > 0 && found < max_records) {
+        char *line;
+        struct ibol_record record;
+        char parse_error[256];
+        int rc;
+
+        rc = read_previous_physical_line(fp, &scan, &line,
+            error, errorsz);
+        if (rc < 0) {
+            fclose(fp);
+            return -1;
+        }
+        if (rc == 0)
+            break;
+
+        parse_error[0] = '\0';
+        rc = ibol_db_parse_line(line, &record,
+            parse_error, sizeof(parse_error));
+        free(line);
+
+        if (rc == 0)
+            records[found++] = record; /* newest -> oldest for now */
+    }
+
+    fclose(fp);
+
+    if (found == 0) {
+        *count_out = 0;
+        if (error != NULL && errorsz > 0)
+            error[0] = '\0';
+        return 0;
+    }
+
+    /* Present callers with natural reading order: oldest -> newest. */
+    {
+        size_t i;
+
+        for (i = 0; i < found / 2; i++) {
+            struct ibol_record tmp;
+            tmp = records[i];
+            records[i] = records[found - 1 - i];
+            records[found - 1 - i] = tmp;
+        }
+    }
+
+    *count_out = found;
+    if (error != NULL && errorsz > 0)
+        error[0] = '\0';
+    return 0;
+}
+
+int
+ibol_db_read_latest(const char *path, struct ibol_record *record,
+    char *error, size_t errorsz)
+{
+    size_t count;
+
+    if (record == NULL) {
+        set_error(error, errorsz, "record is NULL");
+        return -1;
+    }
+
+    count = 0;
+    if (ibol_db_read_recent(path, record, 1, &count,
+            error, errorsz) != 0)
+        return -1;
+
+    if (count != 1) {
+        set_error(error, errorsz, "cache contains no valid IBOL records");
+        return -1;
+    }
+
+    return 0;
+}

--- a/iboldb.h
+++ b/iboldb.h
@@ -1,0 +1,75 @@
+/* iboldb.h */
+
+/*
+ *   SklaffKOM, a simple conference system for UNIX.
+ *
+ *   Copyright (C) 1993-1994  Torbjörn Bååth, Peter Forsberg, Peter Lindberg,
+ *                            Odd Petersson, Carl Sundbom
+ *   Copyright (C) 2026       Peter London
+ *
+ *   Program dedicated to the memory of Staffan Bergström.
+ *
+ *   For questions about this program, mail sklaff@sklaffkom.se
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ */
+
+#ifndef IBOLDB_H
+#define IBOLDB_H
+
+#include "ibol.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+#ifndef SKLAFFDIR
+#define SKLAFFDIR "/usr/local/sklaff"
+#endif
+
+#define IBOL_DB_DEFAULT    SKLAFFDIR "/db/ibol/entries"
+#define IBOL_STATE_DEFAULT SKLAFFDIR "/db/ibol/state"
+
+#define IBOL_DB_MSGID_MAX 256
+
+struct ibol_record {
+    long long timestamp;
+    char msgid[IBOL_DB_MSGID_MAX];
+    char author[IBOL_AUTHOR_MAX];
+    char source[IBOL_SOURCE_MAX];
+    char text[IBOL_TEXT_MAX];
+};
+
+void ibol_record_init(struct ibol_record *record);
+
+/*
+ * Cache format, one physical line per entry:
+ *
+ *   unix_time:MSGID:Author:Source:text
+ *
+ * The characters '\\', ':', '\n', '\r' and '\t' are escaped with a leading
+ * backslash.  Newlines in a multi-part IBOL message therefore remain inside
+ * one physical cache line.
+ */
+int ibol_db_write_record(FILE *fp, const struct ibol_record *record);
+int ibol_db_parse_line(const char *line, struct ibol_record *record,
+    char *error, size_t errorsz);
+
+/* Append one record to an existing cache file. */
+int ibol_db_append(const char *path, const struct ibol_record *record);
+
+/* Read the last valid physical record without scanning the whole cache. */
+int ibol_db_read_latest(const char *path, struct ibol_record *record,
+    char *error, size_t errorsz);
+
+/*
+ * Read up to max_records valid records from the end of the cache.
+ * Returned records are ordered oldest -> newest, suitable for display.
+ * Damaged physical lines are skipped in the same way as read_latest().
+ */
+int ibol_db_read_recent(const char *path, struct ibol_record *records,
+    size_t max_records, size_t *count_out, char *error, size_t errorsz);
+
+#endif /* IBOLDB_H */

--- a/ibolimport.c
+++ b/ibolimport.c
@@ -1,0 +1,1042 @@
+/* ibolimport.c */
+
+#define _POSIX_C_SOURCE 200809L
+
+/*
+ *   SklaffKOM, a simple conference system for UNIX.
+ *
+ *   Copyright (C) 1993-1994  Torbjörn Bååth, Peter Forsberg, Peter Lindberg,
+ *                            Odd Petersson, Carl Sundbom
+ *   Copyright (C) 2026       Peter London
+ *
+ *   Program dedicated to the memory of Staffan Bergström.
+ *
+ *   For questions about this program, mail sklaff@sklaffkom.se
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ */
+
+#include "ftnmsg.h"
+#include "ibol.h"
+#include "iboldb.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#ifndef SKLAFFDIR
+#define SKLAFFDIR "/usr/local/sklaff"
+#endif
+
+#define DEFAULT_IBOL_DB    SKLAFFDIR "/db/ibol/entries"
+#define DEFAULT_IBOL_STATE SKLAFFDIR "/db/ibol/state"
+
+struct msg_file {
+    unsigned long number;
+    char *name;
+};
+
+struct id_set {
+    char **items;
+    size_t count;
+    size_t capacity;
+};
+
+struct import_stats {
+    unsigned long files_seen;
+    unsigned long files_selected;
+    unsigned long ftn_failures;
+    unsigned long non_ibol;
+    unsigned long ibol_messages;
+    unsigned long valid_entries;
+    unsigned long empty_entries;
+    unsigned long malformed_entries;
+    unsigned long duplicate_msgids;
+    unsigned long imported_entries;
+    unsigned long synthetic_msgids;
+    unsigned long fallback_dates;
+};
+
+enum import_mode {
+    MODE_NONE = 0,
+    MODE_REBUILD,
+    MODE_UPDATE,
+    MODE_LATEST
+};
+
+static void usage(FILE *fp, const char *prog);
+static int parse_msg_number(const char *name, unsigned long *number);
+static int collect_msg_files(const char *dirpath, struct msg_file **files_out,
+    size_t *count_out, unsigned long *highest_out);
+static void free_msg_files(struct msg_file *files, size_t count);
+static int compare_msg_files(const void *a, const void *b);
+static int ensure_parent_dirs(const char *path);
+static int read_state(const char *path, unsigned long *last_msg);
+static int write_state_atomic(const char *path, unsigned long last_msg);
+static int id_set_contains(const struct id_set *set, const char *id);
+static int id_set_add(struct id_set *set, const char *id);
+static void id_set_free(struct id_set *set);
+static int load_cache_ids(const char *path, struct id_set *set,
+    unsigned long *bad_lines);
+static int ftn_date_to_timestamp(const char *date, long long *timestamp);
+static void copy_string(char *dst, size_t dstsz, const char *src);
+static int make_record(const char *filepath, unsigned long msgno,
+    const struct fido_msg *msg, const struct ibol_entry *entry,
+    struct ibol_record *record, struct import_stats *stats);
+static int cache_ends_with_newline(const char *path, int *ends_with_newline);
+static int flush_and_sync(FILE *fp);
+static int run_import(enum import_mode mode, const char *area,
+    const char *dbpath, const char *statepath, int dry_run, int verbose);
+static int show_latest(const char *dbpath);
+static void print_summary(enum import_mode mode, const char *area,
+    const char *dbpath, const char *statepath, unsigned long old_state,
+    unsigned long new_state, const struct import_stats *stats, int dry_run);
+
+static void
+usage(FILE *fp, const char *prog)
+{
+    fprintf(fp,
+        "Usage:\n"
+        "  %s --rebuild [options] DIRECTORY\n"
+        "  %s --update  [options] DIRECTORY\n"
+        "  %s --latest  [--db FILE]\n"
+        "\n"
+        "Options:\n"
+        "  --rebuild       rebuild the complete IBOL cache atomically\n"
+        "  --update        import only .MSG files newer than the checkpoint\n"
+        "  --latest        decode and display the latest cached entry\n"
+        "  --db FILE       cache file (default %s)\n"
+        "  --state FILE    checkpoint file (default %s)\n"
+        "  --dry-run       scan and report without changing cache/state\n"
+        "  -v, --verbose   show each imported/skipped IBOL message\n"
+        "  -h, --help      show this help\n"
+        "\n"
+        "Cache format:\n"
+        "  unix_time:MSGID:Author:Source:text\n"
+        "  Colons, backslashes and embedded newlines are escaped.\n"
+        "\n"
+        "Build example:\n"
+        "  cc -Wall -Wextra -O2 -o ibolimport \\\n"
+        "     ibolimport.c iboldb.c ibol.c ftnmsg.c\n",
+        prog, prog, prog, DEFAULT_IBOL_DB, DEFAULT_IBOL_STATE);
+}
+
+static int
+parse_msg_number(const char *name, unsigned long *number)
+{
+    char *end;
+    unsigned long n;
+
+    if (name == NULL || !isdigit((unsigned char)name[0]))
+        return 0;
+
+    errno = 0;
+    n = strtoul(name, &end, 10);
+    if (errno != 0 || end == name || *end != '.')
+        return 0;
+    if (strcasecmp(end, ".msg") != 0)
+        return 0;
+
+    if (number != NULL)
+        *number = n;
+    return 1;
+}
+
+static int
+compare_msg_files(const void *a, const void *b)
+{
+    const struct msg_file *ma = a;
+    const struct msg_file *mb = b;
+
+    if (ma->number < mb->number)
+        return -1;
+    if (ma->number > mb->number)
+        return 1;
+    return strcmp(ma->name, mb->name);
+}
+
+static int
+collect_msg_files(const char *dirpath, struct msg_file **files_out,
+    size_t *count_out, unsigned long *highest_out)
+{
+    DIR *dir;
+    struct dirent *de;
+    struct msg_file *files;
+    size_t count;
+    size_t capacity;
+    unsigned long highest;
+
+    if (files_out == NULL || count_out == NULL || highest_out == NULL)
+        return -1;
+
+    *files_out = NULL;
+    *count_out = 0;
+    *highest_out = 0;
+
+    dir = opendir(dirpath);
+    if (dir == NULL) {
+        fprintf(stderr, "[ERROR] Could not open '%s': %s\n",
+            dirpath, strerror(errno));
+        return -1;
+    }
+
+    files = NULL;
+    count = 0;
+    capacity = 0;
+    highest = 0;
+
+    while ((de = readdir(dir)) != NULL) {
+        unsigned long n;
+        char *copy;
+
+        if (!parse_msg_number(de->d_name, &n))
+            continue;
+
+        if (count == capacity) {
+            size_t new_capacity = capacity == 0 ? 256 : capacity * 2;
+            struct msg_file *tmp = realloc(files,
+                new_capacity * sizeof(*files));
+            if (tmp == NULL) {
+                fprintf(stderr, "[ERROR] Out of memory\n");
+                free_msg_files(files, count);
+                closedir(dir);
+                return -1;
+            }
+            files = tmp;
+            capacity = new_capacity;
+        }
+
+        copy = strdup(de->d_name);
+        if (copy == NULL) {
+            fprintf(stderr, "[ERROR] Out of memory\n");
+            free_msg_files(files, count);
+            closedir(dir);
+            return -1;
+        }
+
+        files[count].number = n;
+        files[count].name = copy;
+        count++;
+        if (n > highest)
+            highest = n;
+    }
+
+    closedir(dir);
+    qsort(files, count, sizeof(*files), compare_msg_files);
+
+    *files_out = files;
+    *count_out = count;
+    *highest_out = highest;
+    return 0;
+}
+
+static void
+free_msg_files(struct msg_file *files, size_t count)
+{
+    size_t i;
+
+    if (files == NULL)
+        return;
+    for (i = 0; i < count; i++)
+        free(files[i].name);
+    free(files);
+}
+
+static int
+ensure_parent_dirs(const char *path)
+{
+    char tmp[PATH_MAX];
+    char *p;
+    size_t len;
+
+    if (path == NULL)
+        return -1;
+    len = strlen(path);
+    if (len == 0 || len >= sizeof(tmp))
+        return -1;
+
+    memcpy(tmp, path, len + 1);
+    p = strrchr(tmp, '/');
+    if (p == NULL)
+        return 0;
+    if (p == tmp)
+        return 0;
+    *p = '\0';
+
+    for (p = tmp + 1; *p != '\0'; p++) {
+        if (*p != '/')
+            continue;
+        *p = '\0';
+        if (mkdir(tmp, 0755) != 0 && errno != EEXIST)
+            return -1;
+        *p = '/';
+    }
+
+    if (mkdir(tmp, 0755) != 0 && errno != EEXIST)
+        return -1;
+    return 0;
+}
+
+static int
+read_state(const char *path, unsigned long *last_msg)
+{
+    FILE *fp;
+    char buf[128];
+    char *end;
+    unsigned long n;
+
+    if (last_msg == NULL)
+        return -1;
+    *last_msg = 0;
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        if (errno == ENOENT)
+            return 0;
+        fprintf(stderr, "[ERROR] Could not read state '%s': %s\n",
+            path, strerror(errno));
+        return -1;
+    }
+
+    if (fgets(buf, sizeof(buf), fp) == NULL) {
+        if (ferror(fp)) {
+            fprintf(stderr, "[ERROR] Could not read state '%s'\n", path);
+            fclose(fp);
+            return -1;
+        }
+        fclose(fp);
+        return 0;
+    }
+    fclose(fp);
+
+    errno = 0;
+    n = strtoul(buf, &end, 10);
+    if (errno != 0 || end == buf) {
+        fprintf(stderr, "[ERROR] Invalid state file '%s'\n", path);
+        return -1;
+    }
+    while (*end != '\0' && isspace((unsigned char)*end))
+        end++;
+    if (*end != '\0') {
+        fprintf(stderr, "[ERROR] Invalid state file '%s'\n", path);
+        return -1;
+    }
+
+    *last_msg = n;
+    return 0;
+}
+
+static int
+write_state_atomic(const char *path, unsigned long last_msg)
+{
+    char tmppath[PATH_MAX];
+    FILE *fp;
+    int rc;
+
+    if (ensure_parent_dirs(path) != 0) {
+        fprintf(stderr, "[ERROR] Could not create parent directory for '%s': %s\n",
+            path, strerror(errno));
+        return -1;
+    }
+
+    if (snprintf(tmppath, sizeof(tmppath), "%s.tmp.%ld", path,
+            (long)getpid()) >= (int)sizeof(tmppath))
+        return -1;
+
+    fp = fopen(tmppath, "w");
+    if (fp == NULL)
+        return -1;
+
+    rc = fprintf(fp, "%lu\n", last_msg) < 0 ? -1 : 0;
+    if (rc == 0)
+        rc = flush_and_sync(fp);
+    if (fclose(fp) != 0)
+        rc = -1;
+
+    if (rc != 0) {
+        unlink(tmppath);
+        return -1;
+    }
+
+    if (rename(tmppath, path) != 0) {
+        unlink(tmppath);
+        return -1;
+    }
+    return 0;
+}
+
+static int
+id_set_contains(const struct id_set *set, const char *id)
+{
+    size_t i;
+
+    if (set == NULL || id == NULL)
+        return 0;
+    for (i = 0; i < set->count; i++) {
+        if (strcmp(set->items[i], id) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+static int
+id_set_add(struct id_set *set, const char *id)
+{
+    char *copy;
+
+    if (set == NULL || id == NULL)
+        return -1;
+    if (id_set_contains(set, id))
+        return 0;
+
+    if (set->count == set->capacity) {
+        size_t new_capacity = set->capacity == 0 ? 128 : set->capacity * 2;
+        char **tmp = realloc(set->items, new_capacity * sizeof(*set->items));
+        if (tmp == NULL)
+            return -1;
+        set->items = tmp;
+        set->capacity = new_capacity;
+    }
+
+    copy = strdup(id);
+    if (copy == NULL)
+        return -1;
+    set->items[set->count++] = copy;
+    return 0;
+}
+
+static void
+id_set_free(struct id_set *set)
+{
+    size_t i;
+
+    if (set == NULL)
+        return;
+    for (i = 0; i < set->count; i++)
+        free(set->items[i]);
+    free(set->items);
+    memset(set, 0, sizeof(*set));
+}
+
+static int
+load_cache_ids(const char *path, struct id_set *set, unsigned long *bad_lines)
+{
+    FILE *fp;
+    char *line;
+    size_t cap;
+    ssize_t n;
+
+    if (bad_lines != NULL)
+        *bad_lines = 0;
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        if (errno == ENOENT)
+            return 0;
+        fprintf(stderr, "[ERROR] Could not open cache '%s': %s\n",
+            path, strerror(errno));
+        return -1;
+    }
+
+    line = NULL;
+    cap = 0;
+    while ((n = getline(&line, &cap, fp)) >= 0) {
+        struct ibol_record record;
+        char error[128];
+
+        (void)n;
+        if (ibol_db_parse_line(line, &record, error, sizeof(error)) != 0) {
+            if (bad_lines != NULL)
+                (*bad_lines)++;
+            continue;
+        }
+        if (id_set_add(set, record.msgid) != 0) {
+            free(line);
+            fclose(fp);
+            return -1;
+        }
+    }
+
+    free(line);
+    if (ferror(fp)) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+    return 0;
+}
+
+static int
+ftn_date_to_timestamp(const char *date, long long *timestamp)
+{
+    static const char *months[] = {
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+    struct tm tmv;
+    char mon[8];
+    int day, year, hour, min, sec, month, i;
+    time_t t;
+
+    if (date == NULL || timestamp == NULL)
+        return -1;
+
+    memset(&tmv, 0, sizeof(tmv));
+    mon[0] = '\0';
+    if (sscanf(date, " %d %7s %d %d:%d:%d",
+            &day, mon, &year, &hour, &min, &sec) != 6)
+        return -1;
+
+    month = -1;
+    for (i = 0; i < 12; i++) {
+        if (strcasecmp(mon, months[i]) == 0) {
+            month = i;
+            break;
+        }
+    }
+    if (month < 0 || day < 1 || day > 31 || hour < 0 || hour > 23 ||
+        min < 0 || min > 59 || sec < 0 || sec > 60)
+        return -1;
+
+    if (year < 70)
+        year += 2000;
+    else if (year < 100)
+        year += 1900;
+
+    tmv.tm_year = year - 1900;
+    tmv.tm_mon = month;
+    tmv.tm_mday = day;
+    tmv.tm_hour = hour;
+    tmv.tm_min = min;
+    tmv.tm_sec = sec;
+    tmv.tm_isdst = -1;
+
+    /* FTN dates carry no timezone.  Interpret them in the importer timezone. */
+    t = mktime(&tmv);
+    if (t == (time_t)-1)
+        return -1;
+
+    *timestamp = (long long)t;
+    return 0;
+}
+
+static void
+copy_string(char *dst, size_t dstsz, const char *src)
+{
+    size_t n;
+
+    if (dst == NULL || dstsz == 0)
+        return;
+    if (src == NULL)
+        src = "";
+
+    n = strlen(src);
+    if (n >= dstsz)
+        n = dstsz - 1;
+    if (n > 0)
+        memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
+static int
+make_record(const char *filepath, unsigned long msgno,
+    const struct fido_msg *msg, const struct ibol_entry *entry,
+    struct ibol_record *record, struct import_stats *stats)
+{
+    struct stat st;
+
+    ibol_record_init(record);
+
+    if (ftn_date_to_timestamp(msg->date, &record->timestamp) != 0) {
+        if (stat(filepath, &st) != 0)
+            return -1;
+        record->timestamp = (long long)st.st_mtime;
+        stats->fallback_dates++;
+    }
+
+    if (msg->msgid[0] != '\0') {
+        copy_string(record->msgid, sizeof(record->msgid), msg->msgid);
+    } else {
+        snprintf(record->msgid, sizeof(record->msgid), "FILE:%lu", msgno);
+        stats->synthetic_msgids++;
+    }
+
+    copy_string(record->author, sizeof(record->author),
+        entry->author[0] ? entry->author : msg->from);
+    copy_string(record->source, sizeof(record->source), entry->source);
+    copy_string(record->text, sizeof(record->text), entry->text);
+    return 0;
+}
+
+static int
+cache_ends_with_newline(const char *path, int *ends_with_newline)
+{
+    FILE *fp;
+    long end;
+    int ch;
+
+    *ends_with_newline = 1;
+    fp = fopen(path, "rb");
+    if (fp == NULL) {
+        if (errno == ENOENT)
+            return 0;
+        return -1;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0 || (end = ftell(fp)) < 0) {
+        fclose(fp);
+        return -1;
+    }
+    if (end == 0) {
+        fclose(fp);
+        return 0;
+    }
+    if (fseek(fp, -1, SEEK_END) != 0) {
+        fclose(fp);
+        return -1;
+    }
+    ch = fgetc(fp);
+    fclose(fp);
+    *ends_with_newline = (ch == '\n' || ch == '\r');
+    return 0;
+}
+
+static int
+flush_and_sync(FILE *fp)
+{
+    if (fflush(fp) != 0)
+        return -1;
+    if (fsync(fileno(fp)) != 0)
+        return -1;
+    return 0;
+}
+
+static int
+run_import(enum import_mode mode, const char *area,
+    const char *dbpath, const char *statepath, int dry_run, int verbose)
+{
+    struct msg_file *files;
+    size_t file_count;
+    unsigned long highest;
+    unsigned long old_state;
+    unsigned long new_state;
+    struct id_set ids;
+    struct import_stats stats;
+    FILE *out;
+    char tmppath[PATH_MAX];
+    int write_failed;
+    int parse_failure_seen;
+    size_t i;
+
+    files = NULL;
+    file_count = 0;
+    highest = 0;
+    old_state = 0;
+    new_state = 0;
+    memset(&ids, 0, sizeof(ids));
+    memset(&stats, 0, sizeof(stats));
+    out = NULL;
+    tmppath[0] = '\0';
+    write_failed = 0;
+    parse_failure_seen = 0;
+
+    if (collect_msg_files(area, &files, &file_count, &highest) != 0)
+        return 1;
+    stats.files_seen = (unsigned long)file_count;
+
+    if (mode == MODE_UPDATE) {
+        struct stat dbst;
+        struct stat stst;
+        unsigned long bad_cache_lines;
+
+        if (read_state(statepath, &old_state) != 0)
+            goto fail;
+
+        if (old_state != 0 && highest < old_state) {
+            fprintf(stderr,
+                "[ERROR] Messagebase highest file is %lu.msg, below checkpoint %lu.msg; use --rebuild\n",
+                highest, old_state);
+            goto fail;
+        }
+
+        if (stat(statepath, &stst) == 0 && stat(dbpath, &dbst) != 0 &&
+            errno == ENOENT) {
+            fprintf(stderr,
+                "[ERROR] State exists but cache '%s' is missing; use --rebuild\n",
+                dbpath);
+            goto fail;
+        }
+
+        if (load_cache_ids(dbpath, &ids, &bad_cache_lines) != 0) {
+            fprintf(stderr, "[ERROR] Could not load existing cache IDs\n");
+            goto fail;
+        }
+        if (verbose && bad_cache_lines != 0)
+            printf("[WARN] Ignored %lu malformed cache line(s)\n",
+                bad_cache_lines);
+    }
+
+    if (!dry_run) {
+        if (ensure_parent_dirs(dbpath) != 0) {
+            fprintf(stderr, "[ERROR] Could not create parent directory for '%s': %s\n",
+                dbpath, strerror(errno));
+            goto fail;
+        }
+
+        if (mode == MODE_REBUILD) {
+            if (snprintf(tmppath, sizeof(tmppath), "%s.tmp.%ld", dbpath,
+                    (long)getpid()) >= (int)sizeof(tmppath)) {
+                fprintf(stderr, "[ERROR] Cache path too long\n");
+                goto fail;
+            }
+            out = fopen(tmppath, "w");
+        } else {
+            int has_newline;
+            if (cache_ends_with_newline(dbpath, &has_newline) != 0) {
+                fprintf(stderr, "[ERROR] Could not inspect cache '%s'\n", dbpath);
+                goto fail;
+            }
+            out = fopen(dbpath, "a");
+            if (out != NULL && !has_newline && fputc('\n', out) == EOF)
+                write_failed = 1;
+        }
+
+        if (out == NULL) {
+            fprintf(stderr, "[ERROR] Could not open cache output: %s\n",
+                strerror(errno));
+            goto fail;
+        }
+    }
+
+    for (i = 0; i < file_count; i++) {
+        char filepath[PATH_MAX];
+        struct fido_msg msg;
+        struct ibol_entry entry;
+        struct ibol_record record;
+        char error[256];
+        int rc;
+
+        if (mode == MODE_UPDATE && files[i].number <= old_state)
+            continue;
+        stats.files_selected++;
+
+        if (snprintf(filepath, sizeof(filepath), "%s/%s", area,
+                files[i].name) >= (int)sizeof(filepath)) {
+            fprintf(stderr, "[ERROR] Path too long: %s/%s\n",
+                area, files[i].name);
+            stats.ftn_failures++;
+            parse_failure_seen = 1;
+            continue;
+        }
+
+        if (read_fido_msg(filepath, &msg) != 0) {
+            stats.ftn_failures++;
+            parse_failure_seen = 1;
+            if (verbose)
+                printf("[FTN ERROR] %s\n", files[i].name);
+            continue;
+        }
+
+        if (!ibol_is_message(&msg)) {
+            stats.non_ibol++;
+            free_fido_msg(&msg);
+            continue;
+        }
+
+        stats.ibol_messages++;
+        rc = ibol_parse_message(&msg, &entry, error, sizeof(error));
+        if (rc == IBOL_PARSE_EMPTY) {
+            stats.empty_entries++;
+            if (verbose)
+                printf("[EMPTY] %-12s %s\n", files[i].name, error);
+            free_fido_msg(&msg);
+            continue;
+        }
+        if (rc != IBOL_PARSE_OK) {
+            stats.malformed_entries++;
+            if (verbose)
+                printf("[MALFORMED] %-12s %s\n", files[i].name, error);
+            free_fido_msg(&msg);
+            continue;
+        }
+        stats.valid_entries++;
+
+        if (make_record(filepath, files[i].number, &msg, &entry,
+                &record, &stats) != 0) {
+            fprintf(stderr, "[ERROR] Could not create cache record for %s\n",
+                files[i].name);
+            free_fido_msg(&msg);
+            write_failed = 1;
+            break;
+        }
+
+        if (id_set_contains(&ids, record.msgid)) {
+            stats.duplicate_msgids++;
+            if (verbose)
+                printf("[DUP] %-12s %s\n", files[i].name, record.msgid);
+            free_fido_msg(&msg);
+            continue;
+        }
+
+        if (!dry_run && ibol_db_write_record(out, &record) != 0) {
+            fprintf(stderr, "[ERROR] Could not write cache record for %s\n",
+                files[i].name);
+            free_fido_msg(&msg);
+            write_failed = 1;
+            break;
+        }
+
+        if (id_set_add(&ids, record.msgid) != 0) {
+            fprintf(stderr, "[ERROR] Out of memory while recording MSGID\n");
+            free_fido_msg(&msg);
+            write_failed = 1;
+            break;
+        }
+
+        stats.imported_entries++;
+        if (verbose)
+            printf("[ADD] %-12s %s @ %s: %s\n", files[i].name,
+                record.author, record.source, entry.text_flat);
+
+        free_fido_msg(&msg);
+    }
+
+    new_state = highest;
+
+    if (!dry_run && out != NULL) {
+        if (!write_failed && flush_and_sync(out) != 0)
+            write_failed = 1;
+        if (fclose(out) != 0)
+            write_failed = 1;
+        out = NULL;
+    }
+
+    if (write_failed)
+        goto fail;
+
+    if (!dry_run && mode == MODE_REBUILD) {
+        if (rename(tmppath, dbpath) != 0) {
+            fprintf(stderr, "[ERROR] Could not install rebuilt cache '%s': %s\n",
+                dbpath, strerror(errno));
+            goto fail;
+        }
+        tmppath[0] = '\0';
+    }
+
+    /*
+     * Never advance the checkpoint past an FTN file we failed to parse.
+     * A later run will retry the range; MSGID de-duplication keeps that safe.
+     */
+    if (!dry_run && !parse_failure_seen) {
+        if (write_state_atomic(statepath, new_state) != 0) {
+            fprintf(stderr, "[ERROR] Could not update state '%s': %s\n",
+                statepath, strerror(errno));
+            goto fail;
+        }
+    } else if (parse_failure_seen) {
+        new_state = old_state;
+    }
+
+    print_summary(mode, area, dbpath, statepath, old_state, new_state,
+        &stats, dry_run);
+
+    id_set_free(&ids);
+    free_msg_files(files, file_count);
+    return parse_failure_seen ? 1 : 0;
+
+fail:
+    if (out != NULL)
+        fclose(out);
+    if (tmppath[0] != '\0')
+        unlink(tmppath);
+    id_set_free(&ids);
+    free_msg_files(files, file_count);
+    return 1;
+}
+
+static void
+print_summary(enum import_mode mode, const char *area,
+    const char *dbpath, const char *statepath, unsigned long old_state,
+    unsigned long new_state, const struct import_stats *stats, int dry_run)
+{
+    printf("\nIBOL import summary\n");
+    printf("===================\n");
+    printf("Mode:                      %s%s\n",
+        mode == MODE_REBUILD ? "rebuild" : "update",
+        dry_run ? " (dry-run)" : "");
+    printf("Source:                    %s\n", area);
+    printf("Cache:                     %s\n", dbpath);
+    printf("State:                     %s\n", statepath);
+    if (mode == MODE_UPDATE)
+        printf("Previous checkpoint:       %lu.msg\n", old_state);
+    printf("New checkpoint:            %lu.msg\n", new_state);
+    printf(".MSG files seen:           %lu\n", stats->files_seen);
+    printf(".MSG files selected:       %lu\n", stats->files_selected);
+    printf("FTN parse failures:        %lu\n", stats->ftn_failures);
+    printf("Non-IBOL messages:         %lu\n", stats->non_ibol);
+    printf("IBOL messages:             %lu\n", stats->ibol_messages);
+    printf("Valid IBOL entries:        %lu\n", stats->valid_entries);
+    printf("Empty IBOL entries:        %lu\n", stats->empty_entries);
+    printf("Malformed IBOL entries:    %lu\n", stats->malformed_entries);
+    printf("Duplicate MSGIDs skipped:  %lu\n", stats->duplicate_msgids);
+    printf("Entries imported:          %lu\n", stats->imported_entries);
+    printf("Synthetic MSGIDs:          %lu\n", stats->synthetic_msgids);
+    printf("Date fallbacks (mtime):    %lu\n", stats->fallback_dates);
+}
+
+static int
+show_latest(const char *dbpath)
+{
+    struct ibol_record record;
+    char error[256];
+    time_t t;
+    struct tm tmv;
+    char datebuf[64];
+
+    if (ibol_db_read_latest(dbpath, &record, error, sizeof(error)) != 0) {
+        fprintf(stderr, "[ERROR] %s\n", error);
+        return 1;
+    }
+
+    datebuf[0] = '\0';
+    t = (time_t)record.timestamp;
+    if (localtime_r(&t, &tmv) != NULL)
+        strftime(datebuf, sizeof(datebuf), "%Y-%m-%d %H:%M:%S", &tmv);
+
+    printf("Latest cached IBOL entry\n");
+    printf("========================\n\n");
+    if (datebuf[0])
+        printf("Timestamp: %lld (%s)\n", record.timestamp, datebuf);
+    else
+        printf("Timestamp: %lld\n", record.timestamp);
+    printf("MSGID:     %s\n", record.msgid);
+    printf("Author:    %s\n", record.author);
+    printf("Source:    %s\n", record.source);
+    printf("Text:\n%s\n", record.text);
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    enum import_mode mode;
+    const char *area;
+    const char *dbpath;
+    const char *statepath;
+    char derived_state[PATH_MAX];
+    int db_was_set;
+    int state_was_set;
+    int dry_run;
+    int verbose;
+    int i;
+
+    mode = MODE_NONE;
+    area = NULL;
+    dbpath = DEFAULT_IBOL_DB;
+    statepath = DEFAULT_IBOL_STATE;
+    derived_state[0] = '\0';
+    db_was_set = 0;
+    state_was_set = 0;
+    dry_run = 0;
+    verbose = 0;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--rebuild") == 0) {
+            if (mode != MODE_NONE) {
+                fprintf(stderr, "[ERROR] Choose exactly one mode\n");
+                return 2;
+            }
+            mode = MODE_REBUILD;
+        } else if (strcmp(argv[i], "--update") == 0) {
+            if (mode != MODE_NONE) {
+                fprintf(stderr, "[ERROR] Choose exactly one mode\n");
+                return 2;
+            }
+            mode = MODE_UPDATE;
+        } else if (strcmp(argv[i], "--latest") == 0) {
+            if (mode != MODE_NONE) {
+                fprintf(stderr, "[ERROR] Choose exactly one mode\n");
+                return 2;
+            }
+            mode = MODE_LATEST;
+        } else if (strcmp(argv[i], "--db") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "[ERROR] --db requires a path\n");
+                return 2;
+            }
+            dbpath = argv[i];
+            db_was_set = 1;
+        } else if (strcmp(argv[i], "--state") == 0) {
+            if (++i >= argc) {
+                fprintf(stderr, "[ERROR] --state requires a path\n");
+                return 2;
+            }
+            statepath = argv[i];
+            state_was_set = 1;
+        } else if (strcmp(argv[i], "--dry-run") == 0) {
+            dry_run = 1;
+        } else if (strcmp(argv[i], "--verbose") == 0 ||
+            strcmp(argv[i], "-v") == 0) {
+            verbose = 1;
+        } else if (strcmp(argv[i], "--help") == 0 ||
+            strcmp(argv[i], "-h") == 0) {
+            usage(stdout, argv[0]);
+            return 0;
+        } else if (argv[i][0] == '-') {
+            fprintf(stderr, "[ERROR] Unknown option: %s\n", argv[i]);
+            usage(stderr, argv[0]);
+            return 2;
+        } else if (area == NULL) {
+            area = argv[i];
+        } else {
+            fprintf(stderr, "[ERROR] Too many source directories\n");
+            return 2;
+        }
+    }
+
+    if (mode == MODE_NONE) {
+        usage(stderr, argv[0]);
+        return 2;
+    }
+
+    if (db_was_set && !state_was_set) {
+        if (snprintf(derived_state, sizeof(derived_state), "%s.state",
+                dbpath) >= (int)sizeof(derived_state)) {
+            fprintf(stderr, "[ERROR] Derived state path is too long\n");
+            return 2;
+        }
+        statepath = derived_state;
+    }
+
+    if (mode == MODE_LATEST) {
+        if (area != NULL || dry_run || verbose || state_was_set) {
+            fprintf(stderr, "[ERROR] --latest only accepts --db FILE\n");
+            return 2;
+        }
+        return show_latest(dbpath);
+    }
+
+    if (area == NULL) {
+        fprintf(stderr, "[ERROR] Source DIRECTORY is required\n");
+        usage(stderr, argv[0]);
+        return 2;
+    }
+
+    return run_import(mode, area, dbpath, statepath, dry_run, verbose);
+}

--- a/ibolview.c
+++ b/ibolview.c
@@ -1,0 +1,278 @@
+/* ibolview.c */
+
+#define _POSIX_C_SOURCE 200809L
+
+/*
+ *   SklaffKOM, a simple conference system for UNIX.
+ *
+ *   Copyright (C) 1993-1994  Torbjörn Bååth, Peter Forsberg, Peter Lindberg,
+ *                            Odd Petersson, Carl Sundbom
+ *   Copyright (C) 2026       Peter London
+ *
+ *   Program dedicated to the memory of Staffan Bergström.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ */
+
+#include "sklaff.h"
+#include "ext_globals.h"
+#include "iboldb.h"
+#include "ibolview.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static int format_ibol_date(long long timestamp, char *datebuf,
+    size_t datebufsz);
+static const char *display_text_start(const struct ibol_record *record,
+    const char *datebuf);
+static int output_ibol_text(const char *text);
+static int output_ibol_record(const struct ibol_record *record);
+
+static int
+format_ibol_date(long long timestamp, char *datebuf, size_t datebufsz)
+{
+    time_t when;
+    struct tm tmv;
+
+    if (datebuf == NULL || datebufsz == 0)
+        return -1;
+
+    when = (time_t)timestamp;
+    if ((long long)when != timestamp || localtime_r(&when, &tmv) == NULL)
+        return -1;
+
+    if (strftime(datebuf, datebufsz, "%Y-%m-%d %H:%M", &tmv) == 0)
+        return -1;
+
+    return 0;
+}
+
+/*
+ * Some IBOL clients put YYYY-MM-DD at the start of the text itself.
+ * If it matches the FTN/cache date, suppress only that display-time prefix.
+ * The cache is never modified.
+ */
+static const char *
+display_text_start(const struct ibol_record *record, const char *datebuf)
+{
+    const char *text;
+
+    if (record == NULL)
+        return "";
+
+    text = record->text;
+    if (datebuf != NULL && strlen(datebuf) >= 10 &&
+        strncmp(text, datebuf, 10) == 0 && text[10] == ' ' &&
+        text[11] != '\0')
+        return text + 11;
+
+    return text;
+}
+
+/* Prefix every physical Oneliner line with a deliberately plain "> ". */
+static int
+output_ibol_text(const char *text)
+{
+    const char *p;
+
+    if (text == NULL)
+        text = "";
+
+    p = text;
+    for (;;) {
+        const char *nl;
+        size_t len;
+
+        nl = strchr(p, '\n');
+        len = nl != NULL ? (size_t)(nl - p) : strlen(p);
+
+        if (output_raw("> ") == -1)
+            return -1;
+
+        if (len > 0 && output_raw("%.*s", (int)len, p) == -1)
+            return -1;
+
+        if (output_raw("\n") == -1)
+            return -1;
+
+        if (nl == NULL)
+            break;
+
+        p = nl + 1;
+        if (*p == '\0')
+            break;
+    }
+
+    return 0;
+}
+
+static int
+output_ibol_record(const struct ibol_record *record)
+{
+    char datebuf[32];
+    const char *author;
+    const char *source;
+    const char *text;
+
+    if (record == NULL)
+        return -1;
+
+    if (format_ibol_date(record->timestamp, datebuf, sizeof(datebuf)) != 0)
+        snprintf(datebuf, sizeof(datebuf), "0000-00-00 00:00");
+
+    author = record->author[0] != '\0' ? record->author : "?";
+    source = record->source[0] != '\0' ? record->source : "?";
+    text = display_text_start(record, datebuf);
+
+    /*
+     * Author/source/body are external BBS data, not SklaffKOM SF7 strings.
+     * Keep them on the raw output path while still allowing ANSI colour.
+     */
+    if (output_ansi_raw_fmt(BR_YELLOW "%s" DOT, "%s", author) == -1)
+        return -1;
+    if (output(" %s ", MSG_IBOL_AT) == -1)
+        return -1;
+    if (output_ansi_raw_fmt(PURPLE "%s" DOT, "%s", source) == -1)
+        return -1;
+    if (output_raw(", ") == -1)
+        return -1;
+    if (output_ansi_raw_fmt(CYAN "%s" DOT, "%s", datebuf) == -1)
+        return -1;
+    if (output_raw(":\n") == -1)
+        return -1;
+
+    if (output_ibol_text(text) != 0)
+        return -1;
+
+    return 0;
+}
+
+int
+display_ibol_entries_from(const char *path, int count)
+{
+    struct ibol_record *records;
+    size_t nrecords;
+    size_t i;
+    char error[256];
+
+    if (count <= 0)
+        return 0;
+    if (path == NULL || *path == '\0')
+        return -1;
+
+    records = calloc((size_t)count, sizeof(*records));
+    if (records == NULL)
+        return -1;
+
+    nrecords = 0;
+    error[0] = '\0';
+    if (ibol_db_read_recent(path, records, (size_t)count, &nrecords,
+            error, sizeof(error)) != 0) {
+        free(records);
+        return -1;
+    }
+
+    if (nrecords == 0) {
+        free(records);
+        return 0;
+    }
+
+    if (output("\n%s\n\n", MSG_IBOL_HEADER) == -1) {
+        free(records);
+        return -1;
+    }
+
+    for (i = nrecords; i > 0; i--) {
+        if (output_ibol_record(&records[i - 1]) != 0) {
+            free(records);
+            return -1;
+        }
+
+        if (i > 1 && output("\n") == -1) {
+            free(records);
+            return -1;
+        }
+    }
+
+    if (output("\n") == -1) {
+        free(records);
+        return -1;
+    }
+
+    free(records);
+    return (int)nrecords;
+}
+
+int
+display_ibol_entries(int count)
+{
+    return display_ibol_entries_from(IBOL_DB_DEFAULT, count);
+}
+
+/*
+ * prompt_ibol_oneliner - optionally queue one local InterBBS Oneliner
+ * ret: 1 if queued, 0 if declined/empty, -1 on local error
+ *
+ * SklaffKOM deliberately emits exactly one physical Oneliner line even
+ * though the importer accepts multi-line posts from other BBS software.
+ *
+ * modified on 2026-08-13, PL
+ */
+int
+prompt_ibol_oneliner(void)
+{
+    LINE answer;
+    LINE text;
+    LINE author;
+
+    if (IBOL_LOGOUT_COUNT <= 0)
+        return 0;
+
+    if (output("%s", MSG_IBOL_WRITE_PROMPT) == -1)
+        return -1;
+
+    input("", answer, 4, 0, 0, 0);
+    down_string(answer);
+
+    if (answer[0] != MSG_YESANSWER)
+        return 0;
+
+    if (output("%s", MSG_IBOL_LINE_PROMPT) == -1)
+        return -1;
+
+    input("", text, IBOL_ONELINER_MAX, 0, 0, 0);
+    rtrim(text);
+
+    while (text[0] == ' ' || text[0] == '\t')
+        memmove(text, text + 1, strlen(text));
+
+    if (text[0] == '\0') {
+        output("\n%s\n\n", MSG_IBOL_EMPTY);
+        return 0;
+    }
+
+    if (strchr(text, '\n') != NULL || strchr(text, '\r') != NULL) {
+        output("\n%s\n\n", MSG_IBOL_SEND_ERROR);
+        return -1;
+    }
+
+    if (user_name(Uid, author) == NULL || author[0] == '\0') {
+        output("\n%s\n\n", MSG_IBOL_SEND_ERROR);
+        return -1;
+    }
+
+    if (queue_ibol_oneliner(Uid, author, text) != 0) {
+        output("\n%s\n\n", MSG_IBOL_SEND_ERROR);
+        return -1;
+    }
+
+    output("\n%s\n\n", MSG_IBOL_SENT);
+    return 1;
+}
+

--- a/ibolview.h
+++ b/ibolview.h
@@ -1,0 +1,36 @@
+/* ibolview.h */
+
+/*
+ *   SklaffKOM, a simple conference system for UNIX.
+ *
+ *   Copyright (C) 1993-1994  Torbjörn Bååth, Peter Forsberg, Peter Lindberg,
+ *                            Odd Petersson, Carl Sundbom
+ *   Copyright (C) 2026       Peter London
+ *
+ *   Program dedicated to the memory of Staffan Bergström.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ */
+
+#ifndef IBOLVIEW_H
+#define IBOLVIEW_H
+
+/*
+ * Display up to count cached IBOL entries, newest -> oldest.
+ *
+ * Returns the number of entries displayed, 0 when count is zero or there
+ * are no usable entries, and -1 if the cache could not be read or output
+ * was interrupted.
+ */
+int display_ibol_entries(int count);
+
+/* Same renderer, but useful for diagnostics/tests with another cache file. */
+int display_ibol_entries_from(const char *path, int count);
+
+/* Ask the current user for one physical oneliner and queue it for FTN export. */
+int prompt_ibol_oneliner(void);
+
+#endif /* IBOLVIEW_H */

--- a/lang.h
+++ b/lang.h
@@ -427,6 +427,16 @@
 #define MSG_MODCONF_BADFTN   "Befintlig FTN-konfiguration {r felaktig."
 #define MSG_MODCONF_SAVED    "M|tet har {ndrats."
 #define MSG_MODCONF_NOCHANGE "Inga {ndringar."
+/* Väggen */
+#define MSG_IBOL_HEADER "Senaste fr}n InterBBS-v{ggen:"
+#define MSG_IBOL_AT     "p}"
+#define MSG_IBOL_DISABLED "InterBBS-v{ggen {r inte aktiverad av systemoperat|ren."
+#define MSG_IBOL_WRITE_PROMPT "Vill du skriva en rad? (j/n) "
+#define MSG_IBOL_LINE_PROMPT  "Din rad: "
+#define MSG_IBOL_EMPTY        "Du skrev ingen rad."
+#define MSG_IBOL_SENT         "Raden {r k|ad f|r utskick."
+#define MSG_IBOL_SEND_ERROR   "Raden kunde inte k|as f|r utskick."
+
 /* conf.c */
 
 #define MSG_CONFSORT	"Sorterar m|teslistan..."
@@ -1214,6 +1224,16 @@
 #define MSG_MODCONF_BADFTN   "The existing FTN configuration is invalid."
 #define MSG_MODCONF_SAVED    "The conference has been changed."
 #define MSG_MODCONF_NOCHANGE "No changes."
+/* The wall */
+#define MSG_IBOL_HEADER "Latest from the InterBBS wall:"
+#define MSG_IBOL_AT     "at"
+#define MSG_IBOL_DISABLED "The InterBBS wall has not been enabled by the sysop."
+#define MSG_IBOL_WRITE_PROMPT "Do you want to write a line? (y/n) "
+#define MSG_IBOL_LINE_PROMPT  "Your line: "
+#define MSG_IBOL_EMPTY        "You did not write a line."
+#define MSG_IBOL_SENT         "The line has been queued for sending."
+#define MSG_IBOL_SEND_ERROR   "The line could not be queued for sending."
+
 /* conf.c */
 
 #define MSG_CONFSORT	"Sorting conference list..."

--- a/lang.h
+++ b/lang.h
@@ -187,8 +187,10 @@
 #define MSG_NORIGHTS	"F|ljande anv{ndare har inte r{ttigheter i"
 #define MSG_CNAMEASK	"M|tets namn: "
 #define MSG_ERRCNAME	"M|tesnamnet krockar med ett annat m|tesnamn."
-#define MSG_CONFTPROMPT	"Typ av m|te, (|)ppet, (s)lutet, (h)emligt, (n)ews, (f)tn: "
+#define MSG_CONFTPROMPT	"Typ av m|te, (l)okalt, (n)ews, (f)tn: "
+#define MSG_CONFACCESSPROMPT	"(|)ppet, (s)lutet, (h)emligt: "
 #define MSG_CONFDEFAULT	"|ppet"
+#define MSG_CONFLOCAL	'l'
 #define MSG_CONFOPEN	'|'
 #define MSG_CONFCLOSED	's'
 #define MSG_CONFSECRET	'h'
@@ -982,8 +984,10 @@
 #define MSG_NORIGHTS	"The following users have no permissions to"
 #define MSG_CNAMEASK	"Conference name: "
 #define MSG_ERRCNAME	"That name collides with another conference name."
-#define MSG_CONFTPROMPT	"Type of conference, (o)pen, (c)losed, (s)ecret, (n)ews, (f)tn: "
+#define MSG_CONFTPROMPT	"Type of conference, (l)ocal, (n)ews, (f)tn: "
+#define MSG_CONFACCESSPROMPT	"(o)pen, (c)losed, (s)ecret: "
 #define MSG_CONFDEFAULT	"open"
+#define MSG_CONFLOCAL	'l'
 #define MSG_CONFOPEN	'o'
 #define MSG_CONFCLOSED	'c'
 #define MSG_CONFSECRET	's'

--- a/lang.h
+++ b/lang.h
@@ -361,6 +361,7 @@
 #define MSG_BLOCKINTRO1	"Redigera blockerade avs{ndare, en per rad."
 #define MSG_BLOCKINTRO2	"Tomma rader och rader som b|rjar med # ignoreras."
 #define MSG_BLOCKED_MSG	"(Text %ld dold: blockerad avs}ndare)"
+#define MSG_JUMPUSERLOCAL "Detta kommando fungerar endast i lokala m|ten."
 /* Nytt Version-kommando */
 #define MSG_VERSIONH1	"UPPHOVSR[TT"
 #define MSG_VERSIONH1U	"==========="
@@ -792,10 +793,10 @@
 #define MSG_ADMHELP17	"   up - Till}ter inloggning i SklaffKOM.\n\n"
 
 /* sklaffacct.c */
-/* Let's do UTF-8 because at least we'll have a higher hitrate than SF7 */
-#define MSG_INNAME	"För och efternamn      : "
+/* Let's do plain ASCII here */
+#define MSG_INNAME	"For och efternamn      : "
 #define MSG_INLOGIN	"Inloggningsnamn        : "
-#define MSG_INPASSWD	"Önskat lösenord        : "
+#define MSG_INPASSWD	"Onskat losenord        : "
 #define MSG_INMODEM	"Modempools-tillgång    : "
 #define MSG_INPOST	"E-postadress           : "
 #define MSG_INTELE	"Telefonnummer          : "
@@ -806,8 +807,8 @@
 #define MSG_INSMODEM	"\nModem    : "
 #define MSG_INSPOST	"\nE-post   : "
 #define MSG_INSTELE	"\nTelefon  : "
-#define MSG_APPLIED	"Tackar för det! \nDin ansökan är registrerad och vi hör snart av oss.\nVälkommen åter.\n\n"
-#define MSG_UIDINUSE	"Inloggningsnamn kan ej anv{ndas. Vänligen välj annat."
+#define MSG_APPLIED	"Tackar för det! \nDin ansokan är registrerad och vi hor snart av oss.\nValkommen tillbaks!.\n\n"
+#define MSG_UIDINUSE	"Inloggningsnamn upptaget. Vanligen valj annat."
 
 /* mailtoss.c */
 
@@ -1158,6 +1159,7 @@
 #define MSG_BLOCKINTRO1 "Enter your list of blocked users, one per row."
 #define MSG_BLOCKINTRO2 "Empty lines, and lines starting with # are ignored."
 #define MSG_BLOCKED_MSG "(Article %ld hidden: the author is on your blocklist)"                  
+#define MSG_JUMPUSERLOCAL "This command only works in local conferences."
 
 /* New version command */
 #define MSG_VERSIONH1	"COPYRIGHT"

--- a/lib/display_header.c
+++ b/lib/display_header.c
@@ -103,7 +103,7 @@ display_header(struct TEXT_HEADER * th, int edit_subject, int type, int dtype, c
 
 int used_news_date = 0;
 struct CONF_ENTRY *ce = get_conf_struct(Current_conf);
-if (ce && ce->type == NEWS_CONF) {
+if (ce && conf_is_news(ce->type)) {
     /* open the stored article and scan headers for "Date:" */
     LINE fname;
     int fd;

--- a/lib/ftn.c
+++ b/lib/ftn.c
@@ -551,7 +551,7 @@ export_ftn_post_if_needed(struct CONF_ENTRY *ce, long textnum)
     if (ce == NULL || textnum <= 0)
         return;
 
-    if (ce->type != FTN_CONF)
+    if (!conf_is_ftn(ce->type))
         return;
 
     if (ce->num <= 0) {

--- a/lib/ftn.c
+++ b/lib/ftn.c
@@ -409,6 +409,106 @@ queue_ftn_export(int confnum, long textnum)
     return 0;
 }
 
+/*
+ * queue_ibol_oneliner - queue one InterBBS Oneliner for FTN export
+ * args: local uid, SklaffKOM display name (SF7), one-line text (SF7)
+ * ret: success (0) or error (-1)
+ *
+ * IBOL is transported through the ordinary FTN export runner, but uses a
+ * typed queue job because it is not a normal SklaffKOM conference text.
+ * The job is written atomically into the existing echomail queue so no new
+ * queue-directory permissions are required.
+ *
+ * modified on 2026-08-13, PL
+ */
+int
+queue_ibol_oneliner(int fromuid, const char *author, const char *text)
+{
+    static unsigned long sequence;
+    char tmpfile[4096];
+    char pendingfile[4096];
+    long now;
+    unsigned long seq;
+    FILE *fp;
+    int n;
+
+    if (fromuid <= 0 || author == NULL || *author == '\0' ||
+        text == NULL || *text == '\0')
+        return -1;
+
+    if (strlen(text) > IBOL_ONELINER_MAX) {
+        dlog(2, "queue_ibol_oneliner: text longer than %d characters",
+            IBOL_ONELINER_MAX);
+        return -1;
+    }
+
+    if (!is_safe_ftn_queue_header_value(author) ||
+        !is_safe_ftn_queue_header_value(text)) {
+        dlog(2, "queue_ibol_oneliner: embedded newline in job value");
+        return -1;
+    }
+
+    now = (long)time(NULL);
+    seq = ++sequence;
+
+    n = snprintf(tmpfile, sizeof(tmpfile),
+        "%s/@ibol.%d.%ld.%ld.%lu.tmp",
+        FTNQUEUE_TMP, fromuid, now, (long)getpid(), seq);
+    if (n < 0 || (size_t)n >= sizeof(tmpfile)) {
+        dlog(2, "queue_ibol_oneliner: tmp filename too long");
+        return -1;
+    }
+
+    n = snprintf(pendingfile, sizeof(pendingfile),
+        "%s/@ibol.%d.%ld.%ld.%lu",
+        FTNQUEUE_PENDING, fromuid, now, (long)getpid(), seq);
+    if (n < 0 || (size_t)n >= sizeof(pendingfile)) {
+        dlog(2, "queue_ibol_oneliner: pending filename too long");
+        return -1;
+    }
+
+    fp = fopen(tmpfile, "w");
+    if (fp == NULL) {
+        dlog(2, "queue_ibol_oneliner: fopen failed for uid %d, errno=%d",
+            fromuid, errno);
+        return -1;
+    }
+
+    if (fprintf(fp,
+            "TYPE: IBOL\n"
+            "FROMUID: %d\n"
+            "AUTHOR: %s\n"
+            "CREATED: %ld\n"
+            "\n"
+            "%s\n",
+            fromuid, author, now, text) < 0) {
+        dlog(2, "queue_ibol_oneliner: write failed for uid %d, errno=%d",
+            fromuid, errno);
+        fclose(fp);
+        unlink(tmpfile);
+        return -1;
+    }
+
+    if (fclose(fp) != 0) {
+        dlog(2, "queue_ibol_oneliner: fclose failed for uid %d, errno=%d",
+            fromuid, errno);
+        unlink(tmpfile);
+        return -1;
+    }
+
+    if (rename(tmpfile, pendingfile) != 0) {
+        dlog(2, "queue_ibol_oneliner: rename failed for uid %d, errno=%d",
+            fromuid, errno);
+        unlink(tmpfile);
+        return -1;
+    }
+
+    dlog(6, "queue_ibol_oneliner: queued IBOL uid %d [%s]",
+        fromuid, author);
+
+    return 0;
+}
+
 int
 queue_ftn_netmail(int fromuid, const char *toname, const char *toaddr,
     const char *subject, const char *body)

--- a/lib/ui.c
+++ b/lib/ui.c
@@ -91,3 +91,17 @@ int output_body_line(const char *line, const char *col)
     }
     return 0;
 }
+
+int
+output_ansi_raw_fmt(const char *ansi_fmt, const char *plain_fmt, ...)
+{
+    va_list args;
+    char buf[HUGE_LINE_LEN];
+    const char *fmt = Ansi_output ? ansi_fmt : plain_fmt;
+
+    va_start(args, plain_fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    return output_raw("%s", buf);   /* returns -1 on error */
+}

--- a/sklaff.h
+++ b/sklaff.h
@@ -388,6 +388,60 @@ conf_is_external(int type)
     return conf_is_news(type) || conf_is_ftn(type);
 }
 
+
+/*
+ * Return the canonical transport for a combined conference type.
+ * OPEN_CONF represents local transport here.
+ */
+static inline int
+conf_transport_type(int type)
+{
+    if (conf_is_news(type))
+        return NEWS_CONF;
+
+    if (conf_is_ftn(type))
+        return FTN_CONF;
+
+    if (conf_access_type(type) >= 0)
+        return OPEN_CONF;
+
+    return -1;
+}
+
+/*
+ * Combine transport and access into the single integer stored in CONF_FILE.
+ */
+static inline int
+conf_make_type(int transport, int access)
+{
+    if (access != OPEN_CONF &&
+        access != CLOSED_CONF &&
+        access != SECRET_CONF)
+        return -1;
+
+    switch (transport) {
+    case OPEN_CONF:
+        return access;
+
+    case NEWS_CONF:
+        if (access == CLOSED_CONF)
+            return NEWS_CLOSED_CONF;
+        if (access == SECRET_CONF)
+            return NEWS_SECRET_CONF;
+        return NEWS_CONF;
+
+    case FTN_CONF:
+        if (access == CLOSED_CONF)
+            return FTN_CLOSED_CONF;
+        if (access == SECRET_CONF)
+            return FTN_SECRET_CONF;
+        return FTN_CONF;
+
+    default:
+        return -1;
+    }
+}
+
 /* Defines for text types */
 
 #define TYPE_TEXT		0

--- a/sklaff.h
+++ b/sklaff.h
@@ -320,6 +320,66 @@ https://github.com/joakimmelin/sklaffkom/wiki/Install-Instructions */
 #define NEWS_CONF	3
 #define FTN_CONF	4
 
+#define NEWS_CLOSED_CONF	5
+#define NEWS_SECRET_CONF	6
+#define FTN_CLOSED_CONF	7
+#define FTN_SECRET_CONF	8
+
+/*
+ * Conference type is stored as one integer for backwards compatibility.
+ *
+ * Values 0..4 retain their historic meaning.  The helpers below separate
+ * the two concepts that are encoded in that integer:
+ *
+ *   transport: local / news / FTN
+ *   access:    open / closed / secret
+ */
+static inline int
+conf_access_type(int type)
+{
+    switch (type) {
+    case OPEN_CONF:
+    case NEWS_CONF:
+    case FTN_CONF:
+        return OPEN_CONF;
+
+    case CLOSED_CONF:
+    case NEWS_CLOSED_CONF:
+    case FTN_CLOSED_CONF:
+        return CLOSED_CONF;
+
+    case SECRET_CONF:
+    case NEWS_SECRET_CONF:
+    case FTN_SECRET_CONF:
+        return SECRET_CONF;
+
+    default:
+        return -1;
+    }
+}
+
+static inline int
+conf_is_news(int type)
+{
+    return type == NEWS_CONF ||
+           type == NEWS_CLOSED_CONF ||
+           type == NEWS_SECRET_CONF;
+}
+
+static inline int
+conf_is_ftn(int type)
+{
+    return type == FTN_CONF ||
+           type == FTN_CLOSED_CONF ||
+           type == FTN_SECRET_CONF;
+}
+
+static inline int
+conf_is_external(int type)
+{
+    return conf_is_news(type) || conf_is_ftn(type);
+}
+
 /* Defines for text types */
 
 #define TYPE_TEXT		0

--- a/sklaff.h
+++ b/sklaff.h
@@ -41,6 +41,14 @@
 #define ENABLE_CHARSET_HANDSHAKE 1
 #endif
 
+/* Number of InterBBS Oneliners displayed at checkout. 0 to disable. */
+#define IBOL_LOGOUT_COUNT 0
+
+/* InterBBS Oneliner (IBOL) transport settings. */
+#define IBOL_ONELINER_MAX 65
+#define IBOL_FTN_DOMAIN   "fsxnet"
+#define IBOL_FTN_AREA     "FSX_DAT"
+
 /* Define full path to crashmail.prefs */
 #ifndef CRASHMAIL_PREFS_FILE
 #define CRASHMAIL_PREFS_FILE "/ftn/etc/crashmail.prefs"
@@ -470,6 +478,7 @@ int  detect_terminal_lines(void);														/* 2025-08-10 PL */
 /* lib/ui.c */
 
 int  output_ansi_fmt(const char *ansi_fmt, const char *plain_fmt, ...); 				/* 2025-07-30 PL */
+int output_ansi_raw_fmt(const char *ansi_fmt, const char *plain_fmt, ...);				/* 2026-08-13 PL */
 void clear_prompt(int num); 															/* Little helper to avoid extra '(') 2025-08-26 PL */
 void clear_prompt_cols(int cols);														/* 2025-08-30 PL */
 void clear_screen(void);                                                                     /* More sophisticated cls to use outside of commands.c */
@@ -609,6 +618,7 @@ int cmd_version(char *args); /*2026-06-02 PL */
 int cmd_block_user(char *args); /* 2026-06-16, PL */
 int cmd_change_charset(char *); /* 2026-08-07 PL */
 int cmd_mod_conf(char *); /* 2026-08-09 PL */
+int cmd_wall(char *args); /* 2026-08-12 PL */
 
 /* admin.c */
 
@@ -718,6 +728,11 @@ int save_flags(void);	/* PL 2026-08-05 improved save_flags procedure */
 /* footnote.c */
 
 void show_footnote_block(int conf, long num, char *home, int has_comments);					/* 2025-10-15 helper to render the footnote (if there is one) */
+
+/* ibolview.c */
+int display_ibol_entries(int count);
+int prompt_ibol_oneliner(void); /* 2026-08-13 PL */
+int queue_ibol_oneliner(int fromuid, const char *author, const char *text); /* 2026-08-13 PL */
 
 /* mailparse.c */
 

--- a/text.c
+++ b/text.c
@@ -1115,8 +1115,8 @@ output("\n");
 	*
 	* modified on 2026-06-18, PL
 	*/
-	raw_ftn_output = (Utf8 && conf_type == FTN_CONF);
-	raw_news_output = (Utf8 && conf_type == NEWS_CONF);
+	raw_ftn_output = (Utf8 && conf_is_ftn(conf_type));
+	raw_news_output = (Utf8 && conf_is_news(conf_type));
 	raw_external_output = (raw_ftn_output || raw_news_output);
     
     if (Last_conf) {

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-VERSION='1.33rc1'
+VERSION='1.33rc2'
 COMPILE=`cat .compile`
 COMPILE=`expr ${COMPILE:-0} + 1`
 echo $COMPILE > .compile


### PR DESCRIPTION
* Bumped the version to v1.33rc2. I'm thinking maybe rc3 could be an official release. Or pre-relase, or whatever it's called. The UX needs some more polish before that. English version needs more testing too.

* We can now create hidden or secret news and ftn- conferences. This one took a while to figure out. We now have new conf_types defined in sklaff.h :

* Defines for conf_type */                                                     
                                                                                
```
#define OPEN_CONF   0                                                           
#define CLOSED_CONF 1                                                           
#define SECRET_CONF 2                                                           
#define NEWS_CONF   3                                                           
#define FTN_CONF    4                                                           
                                                                                
#define NEWS_CLOSED_CONF    5                                                   
#define NEWS_SECRET_CONF    6                                                   
#define FTN_CLOSED_CONF 7                                                       
#define FTN_SECRET_CONF 8    
```        

There are many, many places where SklaffKOM checks the conf_type and behaves accordingly. I did test this a lot, and I'm fairly sure I've caught every instance. ftntoss keeps running as usual, it seems.

* This PR adds InterBBS oneliner support. I wrote a [wiki post](https://github.com/loppanloppis/sklaffkom-dev/wiki/InterBBS-oneliner-(IBOL)-support) describing the whole thing. It's disabled in sklaff.h by default.

Enjoy!