### PR TITLE
Fix: Don't wait for RETURN during login if there is no news file + prepare parser with group support

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -393,6 +393,29 @@ wait_for_intro_continue(void)
     input("", answer, LINE_LEN, 0, 0, 1);
 }
 
+/*
+ * news_file_available - check whether there is a news file that
+ * this language version of SklaffKOM can display.
+ */
+static int
+news_file_available(void)
+{
+#ifdef SWEDISH
+    if (file_exists(NEWS_FILE_SWE) != -1)
+        return 1;
+#else
+    if (file_exists(NEWS_FILE_ENG) != -1)
+        return 1;
+#endif
+
+    /*
+     * The generic news file is the fallback.
+     */
+    if (file_exists(NEWS_FILE) != -1)
+        return 1;
+
+    return 0;
+}
 
 /*
  * display_alternative_intro_user - display rookie information, news,
@@ -405,25 +428,35 @@ display_alternative_intro_user(void)
     LINE name;
     struct USER_ENTRY *ue;
 
+    int intro_shown = 0;
+    int news_shown = 0;
+
     /*
      * Rookie information is only shown while Rookie mode is enabled.
      */
-    if (Rookie_mode)
+    if (Rookie_mode) {
         display_intro();
+        intro_shown = 1;
+    }
 
     /*
      * TODO: Later, only display news when the file has changed since
      * the user last saw it.
      */
-    dlog(6, "We try to display news-file");
-    display_news();
+    if (news_file_available()) {
+        dlog(6, "We try to display news-file");
+        display_news();
+        news_shown = 1;
+    }
 
     /*
-     * For now the alternative intro always pauses here. Once the news
-     * tracking is implemented, only pause if intro or news was shown.
+     * Only pause and clear the screen if we actually displayed
+     * rookie information or news.
      */
-    wait_for_intro_continue();
-    clear_screen();
+    if (intro_shown || news_shown) {
+        wait_for_intro_continue();
+        clear_screen();
+    }
 
     /*
     * Sklaff version goes here for now

--- a/buf.c
+++ b/buf.c
@@ -132,25 +132,55 @@ get_conf_entry(char *buf, struct CONF_ENTRY * ce)
  * args: buffer (buf), pointer to PARSE_ENTRY (pe)
  * ret: next position in buffer or NULL
  */
+
 char *
-get_parse_entry(char *buf, struct PARSE_ENTRY * pe)
+get_parse_entry(char *buf, struct PARSE_ENTRY *pe)
 {
     int res;
+    LINE group;
 
-    memset(pe->cmd, 0, LINE_LEN);
-    memset(pe->func, 0, LINE_LEN);
-    memset(pe->help, 0, LINE_LEN);
+    memset(pe->cmd, 0, sizeof(pe->cmd));
+    memset(pe->func, 0, sizeof(pe->func));
+    memset(pe->help, 0, sizeof(pe->help));
+
+    /*
+     * Backwards compatibility:
+     * old three-field parse entries default to Other.
+     */
+    pe->group = 'O';
+
     for (;;) {
-        res = sscanf(buf, "%[^:#\n]:%[^#:\n]:%[^#:\n]'", pe->cmd,
-            pe->func, pe->help);
+        memset(group, 0, sizeof(group));
+
+        res = sscanf(buf,
+            "%[^:#\n]:%[^#:\n]:%[^#:\n]:%[^#:\n]",
+            pe->cmd, pe->func, pe->help, group);
+
         if (res == -1)
             return NULL;
+
         rtrim(pe->cmd);
         rtrim(pe->func);
         rtrim(pe->help);
+
+        /*
+         * Fourth field is optional while the parse files
+         * are being converted.
+         */
+        if (res >= 4) {
+            ltrim(group);
+            rtrim(group);
+
+            if (*group)
+                pe->group =
+                    (char)toupper((unsigned char)group[0]);
+        }
+
         buf = strchr(buf, '\n');
+
         while (buf && (*buf == '\n'))
             buf++;
+
         if (res || (buf == NULL))
             return buf;
     }

--- a/commands.c
+++ b/commands.c
@@ -7151,6 +7151,7 @@ cmd_alias(char *args)
                 strcpy(Par_ent[j].func, Par_ent[i].func);
                 strcpy(Par_ent[j].cmd, cmd);
                 strcpy(Par_ent[j].help, Par_ent[i].help);
+                Par_ent[j].group = Par_ent[i].group;
                 Par_ent[j].addr = Par_ent[i].addr;
                 if (!Logging_in) {
                     output("\n%s %s %s %s.\n\n",

--- a/struct.h
+++ b/struct.h
@@ -82,6 +82,7 @@ struct PARSE_ENTRY {
     LINE func;                  /* name of function to call */
     LINE cmd;                   /* specification of the command */
     LINE help;                  /* a short description of what it does */
+    char group;                 /* command group, e.g. T, C, F, ... */
     cmd_func_t *addr;           /* address of the function to call */
 };
 


### PR DESCRIPTION
Tiny fix for the new "alternate startup screen".

SklaffKOM expected a RETURN key press after displaying news - even if there was no news to display. SysOp can chose to not display any news by just deleting/renaming the corresponding files (news, news.eng and news.swe), and if that's the case, this fix makes sure SklaffKOM does not expect a key press to move forward in the login procedure :).

Cheers