### PR TITLE
Fix ibolimport build and clean up Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ SURVREPOBJ=survreport.o
 FTCOBJ=forwardtoconf.o
 FTYOBJ=forwardtoyell.o
 IBOLIMPORTOBJ=ibolimport.o ibol.o iboldb.o ftnmsg.o
+IBOLMSGDUMPOBJ=ibolmsgdump.o ibol.o ftnmsg.o
 
 SKLAFFLIB=lib/libsklaff.a
 
@@ -143,7 +144,10 @@ forwardtoyell: $(SKLAFFLIB) $(FTYOBJ) $(OBJS)
 
 ibolimport: $(IBOLIMPORTOBJ)
 	$(CC) -o ibolimport $(IBOLIMPORTOBJ)
-	
+
+ibolmsgdump: $(IBOLMSGDUMPOBJ)
+	$(CC) -o ibolmsgdump $(IBOLMSGDUMPOBJ)
+
 version.c:
 	@./version.sh
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SKLAFFSYS = LINUX	# Linux
 
 CC=gcc
 SKLAFFFLAGS = -D$(SKLAFFSYS) -DSKLAFFDIR=\"$(SKLAFFDIR)\" -DSKLAFFBIN=\"$(SKLAFFBIN)\"
-CFLAGS = $(SKLAFFFLAGS) -O2 -g -pipe -Wall -Werror
+CFLAGS = $(SKLAFFFLAGS) -O2 -g -pipe -Wall
 
 # uncomment for SYSV
 #LIBS=-lc_s -lsklaff -ltermcap -lcposix -linet -lm
@@ -74,6 +74,7 @@ FTNTOBJ=ftntoss.o ftnconfig.o ftnmsg.o ftnnetmail.o utf.o version.o
 SURVREPOBJ=survreport.o
 FTCOBJ=forwardtoconf.o
 FTYOBJ=forwardtoyell.o
+IBOLIMPORTOBJ=ibolimport.o ibol.o iboldb.o ftnmsg.o
 
 SKLAFFLIB=lib/libsklaff.a
 
@@ -91,6 +92,10 @@ $(FTNTOBJ): sklaff.h struct.h ftnmsg.h
 $(SURVREPOBJ): sklaff.h globals.h struct.h lang.h
 $(FTCOBJ): sklaff.h globals.h struct.h lang.h
 $(FTYOBJ): sklaff.h globals.h struct.h lang.h
+
+ibolimport.o: ftnmsg.h ibol.h iboldb.h
+ibol.o: ibol.h ftnmsg.h
+iboldb.o: iboldb.h
 
 sklaffkom: $(SKLAFFLIB) $(KOMOBJ) $(OBJS)
 	$(CC) -g -o sklaffkom $(KOMOBJ) $(OBJS) -Llib $(LIBS)
@@ -136,13 +141,16 @@ forwardtoyell: $(SKLAFFLIB) $(FTYOBJ) $(OBJS)
 	$(CC) -o forwardtoyell $(FTYOBJ) $(OBJS) -Llib $(LIBS)
 	strip forwardtoyell
 
+ibolimport: $(IBOLIMPORTOBJ)
+	$(CC) -o ibolimport $(IBOLIMPORTOBJ)
+	
 version.c:
 	@./version.sh
 
 $(SKLAFFLIB):
 	(cd lib; $(MAKE) CC=$(CC) CFLAGS='$(CFLAGS) -I..')
 
-install: sklaffkom sklaffadm sklaffacct survreport sklaffwho newstoss ftntoss
+install: sklaffkom sklaffadm sklaffacct survreport sklaffwho newstoss mailtoss ftntoss ibolimport
 	@echo Making libraries
 	-mkdir $(SKLAFFDIR)
 	-mkdir $(SKLAFFDIR)/etc
@@ -232,8 +240,13 @@ installdb:
 	chmod og-rxw $(SKLAFFDIR)/etc/help.eng/*
 
 clean:
-	(cd lib; make clean)
-	-rm -f *.o *.a \#* *~ core sklaffkom sklaffadm sklaffacct mailtoss newstoss ftntoss survreport sklaffwho version.c
+	(cd lib; $(MAKE) clean)
+	-rm -f *.o *.a \#* *~ core \
+	    sklaffkom sklaffadm sklaffacct \
+	    mailtoss newstoss ftntoss survreport sklaffwho \
+	    ibolimport ibolmsgdump \
+	    forwardtoconf forwardtoyell \
+	    version.c
 
 # distrib is rewritten 2025-08-16 by PL to work in our modern times
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,7 +3,7 @@
 #
 
 OBJS=tty_raw.o tty_reset.o sig_setup.o sig_reset.o critical.o non_critical.o\
-lock.o unlock.o input.o input.o output.o down_string.o up_string.o\
+lock.o unlock.o input.o output.o down_string.o up_string.o\
 time_string.o sys_error.o file_size.o rawio.o user_dir.o cmp_strings.o\
 copy_file.o wc.o rtrim.o ltrim.o parse_string.o file_exists.o hostname.o\
 sort_util.o prog_name.o mbox_dir.o compat.o misc.o ui.o display_header.o\


### PR DESCRIPTION
Makefile:
- remove -Werror
- build ibolimport
- make install depend on mailtoss + ibolimport
- clean ibolimport and forgotten utility binaries
- use $(MAKE) recursively

lib/Makefile:
- remove duplicate input.o